### PR TITLE
Inject SuperAdmin view model and configure tab contexts

### DIFF
--- a/Interfaces/ISuperAdminViewModel.cs
+++ b/Interfaces/ISuperAdminViewModel.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Hotel_Booking_System.Interfaces
 {
     interface ISuperAdminViewModel
     {
+        Task LoadDataAsync();
     }
 }
+

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -847,7 +847,7 @@ Margin="50" Padding="0">
             </TabItem>
 
 
-            <TabItem Header="Admin Bookings &amp; Requests">
+            <TabItem x:Name="AdminBookingsRequestsTab" Header="Admin Bookings &amp; Requests">
                 <Grid Margin="30,20">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -16,12 +16,19 @@ namespace Hotel_Booking_System.Views
     {
         private readonly IPaymentViewModel _paymentViewModel = App.Provider.GetRequiredService<IPaymentViewModel>();
         private readonly IAdminViewModel _adminViewModel = App.Provider.GetRequiredService<IAdminViewModel>();
+        private readonly ISuperAdminViewModel _superAdminViewModel = App.Provider.GetRequiredService<ISuperAdminViewModel>();
+
         public SuperAdminWindow()
         {
             InitializeComponent();
+            DataContext = _superAdminViewModel;
             PaymentSummaryTab.DataContext = _paymentViewModel;
-            Loaded += async (s, e) => await _paymentViewModel.LoadPaymentsAsync();
-            DataContext = _adminViewModel;
+            AdminBookingsRequestsTab.DataContext = _adminViewModel;
+            Loaded += async (s, e) =>
+            {
+                await _paymentViewModel.LoadPaymentsAsync();
+                await _superAdminViewModel.LoadDataAsync();
+            };
         }
        
      


### PR DESCRIPTION
## Summary
- inject `ISuperAdminViewModel` and use it as `SuperAdminWindow`'s DataContext
- keep payment summary bound to `IPaymentViewModel` and admin bookings tab bound to `IAdminViewModel`
- load SuperAdmin data on window startup

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c4a8be2883339e1077b1aa40caf2