### PR TITLE
Bind admin headers to current user names

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -92,6 +92,7 @@ namespace Hotel_Booking_System
                               .AddScoped<IAdminViewModel, AdminViewModel>()
                               .AddScoped<IUserViewModel, UserViewModel>()
                               .AddScoped<IAdminViewModel, AdminViewModel>()
+                              .AddScoped<IHotelAdminViewModel, HotelAdminViewModel>()
                               .BuildServiceProvider();
         }
     }

--- a/Interfaces/IHotelAdminViewModel.cs
+++ b/Interfaces/IHotelAdminViewModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Hotel_Booking_System.DomainModels;
+
+namespace Hotel_Booking_System.Interfaces
+{
+    public interface IHotelAdminViewModel
+    {
+        ObservableCollection<Review> Reviews { get; }
+        User CurrentUser { get; set; }
+        Task LoadReviewsAsync();
+    }
+}

--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -1,0 +1,53 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Hotel_Booking_System.DomainModels;
+using Hotel_Booking_System.Interfaces;
+using Hotel_Booking_System.Services;
+using Hotel_Manager.FrameWorks;
+
+namespace Hotel_Booking_System.ViewModels
+{
+    public class HotelAdminViewModel : Bindable, IHotelAdminViewModel
+    {
+        private readonly IReviewRepository _reviewRepository;
+        private readonly IUserRepository _userRepository;
+        private string _userEmail = string.Empty;
+        private User _currentUser = new();
+
+        public ObservableCollection<Review> Reviews { get; } = new();
+
+        public User CurrentUser
+        {
+            get => _currentUser;
+            set => Set(ref _currentUser, value);
+        }
+
+        public HotelAdminViewModel(IReviewRepository reviewRepository, IUserRepository userRepository)
+        {
+            _reviewRepository = reviewRepository;
+            _userRepository = userRepository;
+
+            WeakReferenceMessenger.Default.Register<HotelAdminViewModel, MessageService>(this, (recipient, message) =>
+            {
+                recipient._userEmail = message.Value;
+                recipient.LoadCurrentUser();
+            });
+        }
+
+        public async Task LoadReviewsAsync()
+        {
+            var reviews = await _reviewRepository.GetAllAsync();
+            Reviews.Clear();
+            foreach (var review in reviews)
+            {
+                Reviews.Add(review);
+            }
+        }
+
+        private async void LoadCurrentUser()
+        {
+            CurrentUser = await _userRepository.GetByEmailAsync(_userEmail);
+        }
+    }
+}

--- a/ViewModels/LoginViewModel.cs
+++ b/ViewModels/LoginViewModel.cs
@@ -53,15 +53,15 @@ namespace Hotel_Booking_System.ViewModels
             }
             else if (user != null && user.Email == email && _authenticationService.VerifyPassword(Password, user.Password) && user.Role == "SuperAdmin")
             {
-                WeakReferenceMessenger.Default.Send(new MessageService(email));
                 _navigationService.NavigateToSuperAdmin();
+                WeakReferenceMessenger.Default.Send(new MessageService(email));
                 await SaveCredentials();
 
             }
             else if (user != null && user.Email == email && _authenticationService.VerifyPassword(Password, user.Password) && user.Role == "HotelAdmin")
             {
-                WeakReferenceMessenger.Default.Send(new MessageService(email));
                 //_navigationService.NavigateToHotel();
+                WeakReferenceMessenger.Default.Send(new MessageService(email));
                 await SaveCredentials();
 
             }

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -31,12 +31,8 @@
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="30,0">
-                <TextBlock Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom">
-                Xin Chào,
-                </TextBlock>
-                <TextBlock Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom">
-                Trung
-                </TextBlock>
+                <TextBlock Text="Xin Chào," Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom"/>
+                <TextBlock Text="{Binding CurrentUser.FullName}" Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom"/>
 
                 <Button Content="Logout" Style="{StaticResource PrimaryButton}" Width="100"
                    Background="#FFFF5722" Margin="5,0,0,0"/>

--- a/Views/HotelAdminWindow.xaml.cs
+++ b/Views/HotelAdminWindow.xaml.cs
@@ -11,8 +11,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using System.Collections.ObjectModel;
-using Hotel_Booking_System.DomainModels;
 using Hotel_Booking_System.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,15 +21,13 @@ namespace Hotel_Booking_System.Views
     /// </summary>
     public partial class HotelAdminWindow : Window
     {
-        private readonly IReviewRepository _reviewRepository;
-        public ObservableCollection<Review> Reviews { get; set; }
+        private readonly IHotelAdminViewModel _hotelAdminViewModel = App.Provider.GetRequiredService<IHotelAdminViewModel>();
 
         public HotelAdminWindow()
         {
             InitializeComponent();
-            _reviewRepository = App.Provider.GetRequiredService<IReviewRepository>();
-            Reviews = new ObservableCollection<Review>(_reviewRepository.GetAllAsync().Result);
-            DataContext = this;
+            DataContext = _hotelAdminViewModel;
+            Loaded += async (s, e) => await _hotelAdminViewModel.LoadReviewsAsync();
         }
     }
 }

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -30,12 +30,8 @@
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="30,0">
-                <TextBlock Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom">
-                    Xin Chào,
-                </TextBlock>
-                <TextBlock Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom">
-                    Trung
-                </TextBlock>
+                <TextBlock Text="Xin Chào," Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom"/>
+                <TextBlock Text="{Binding CurrentUser.FullName}" Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom"/>
 
                 <Button Content="Logout" Style="{StaticResource PrimaryButton}" Width="100"
                        Background="#FFFF5722" Margin="5,0,0,0"/>


### PR DESCRIPTION
## Summary
- Bind Super Admin and Hotel Admin window headers to `CurrentUser.FullName`
- Load `CurrentUser` via messenger in admin view models
- Introduce `HotelAdminViewModel` and DI registration for hotel admin

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c4bacba88333b5d828720624bec6