### PR TITLE
Fix HotelAdminWindow initialization

### DIFF
--- a/Views/HotelAdminWindow.xaml.cs
+++ b/Views/HotelAdminWindow.xaml.cs
@@ -4,7 +4,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using Hotel_Booking_System.ViewModels;
 using Hotel_Booking_System.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,14 +14,8 @@ namespace Hotel_Booking_System.Views
     /// </summary>
     public partial class HotelAdminWindow : Window
     {
-        public HotelAdminViewModel ViewModel { get; }
+        private readonly IHotelAdminViewModel _hotelAdminViewModel = App.Provider.GetRequiredService<IHotelAdminViewModel>();
 
-        public HotelAdminWindow()
-        {
-            InitializeComponent();
-            _viewModel = App.Provider.GetRequiredService<IHotelAdminViewModel>();
-            DataContext = _viewModel;
-         private readonly IHotelAdminViewModel  _hotelAdminViewModel = App.Provider.GetRequiredService<IHotelAdminViewModel>();
         public HotelAdminWindow()
         {
             InitializeComponent();


### PR DESCRIPTION
## Summary
- fix HotelAdminWindow view model initialization and remove redundant constructor

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cd289a208333bbb3a481a8797bf0