### PR TITLE
Remove redundant public keywords and fix SignUp password typo

### DIFF
--- a/Interfaces/IForgotPasswordViewModel.cs
+++ b/Interfaces/IForgotPasswordViewModel.cs
@@ -8,10 +8,10 @@ namespace Hotel_Booking_System.Interfaces
 {
     interface IForgotPasswordViewModel
     {
-        public string StepOneStatus { get; set; }
-        public string StepTwoStatus { get; set; }
-        public string StepThreeStatus { get; set; }
-        public string NewPassword { get; set; }
-        public string NewPasswordConfirm { get; set; }
+        string StepOneStatus { get; set; }
+        string StepTwoStatus { get; set; }
+        string StepThreeStatus { get; set; }
+        string NewPassword { get; set; }
+        string NewPasswordConfirm { get; set; }
     }
 }

--- a/Interfaces/ILoginViewModel.cs
+++ b/Interfaces/ILoginViewModel.cs
@@ -10,8 +10,8 @@ namespace Hotel_Booking_System.Interfaces
 {
     interface ILoginViewModel
     {
-        public string Password { get; set; }
-        public string Email { get; set; }   
-        public bool IsSavedCredentials { get; set; }
+        string Password { get; set; }
+        string Email { get; set; }
+        bool IsSavedCredentials { get; set; }
     }
 }

--- a/Interfaces/ISignUpViewModel.cs
+++ b/Interfaces/ISignUpViewModel.cs
@@ -8,7 +8,7 @@ namespace Hotel_Booking_System.Interfaces
 {
     interface ISignUpViewModel
     {
-        public string Passoword { get; set; }
-        public string PasswordConfirmed { get; set; }
+        string Password { get; set; }
+        string PasswordConfirmed { get; set; }
     }
 }

--- a/ViewModels/SignUpViewModel.cs
+++ b/ViewModels/SignUpViewModel.cs
@@ -31,7 +31,7 @@ namespace Hotel_Booking_System.ViewModels
 
 
 
-        public string Passoword { get; set; }
+        public string Password { get; set; }
         public string PasswordConfirmed { get; set; }
 
         [RelayCommand(CanExecute = nameof(CanSendOTP))]
@@ -70,7 +70,7 @@ namespace Hotel_Booking_System.ViewModels
         [RelayCommand]
         private async Task CreateAccount(object para)
         {
-            if(Passoword != PasswordConfirmed)
+            if (Password != PasswordConfirmed)
             {
                 MessageBox.Show("Mật khẩu không khớp vui lòng kiểm tra lại");
                 return;
@@ -85,7 +85,7 @@ namespace Hotel_Booking_System.ViewModels
             }
             try
             {
-                string hashedPassword = _authentication.HashPassword(Passoword);
+                string hashedPassword = _authentication.HashPassword(Password);
                 data.Item1.Password = hashedPassword;
                 data.Item1.Role = "User";
 

--- a/Views/SignUpWindow.xaml.cs
+++ b/Views/SignUpWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace Hotel_Booking_System.Views
             InitializeComponent();
             DataContext = _signupViewModel;
             txtConfirmedPassword.PasswordChanged += (s, e) => { _signupViewModel.PasswordConfirmed = txtConfirmedPassword.Password; };
-            txtPassword.PasswordChanged += (s, e) => { _signupViewModel.Passoword = txtPassword.Password; };
+            txtPassword.PasswordChanged += (s, e) => { _signupViewModel.Password = txtPassword.Password; };
             
         }
     }


### PR DESCRIPTION
## Summary
- Drop unnecessary `public` modifiers from view model interfaces
- Rename SignUp `Passoword` property to `Password` and update references

## Testing
- `dotnet build` *(fails: The imported project "/usr/lib/dotnet/sdk/8.0.119/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d0a03f988333a4fe90d98cfbcaa6