### PR TITLE
Use async credential loading in LoginViewModel

### DIFF
--- a/Interfaces/ILoginViewModel.cs
+++ b/Interfaces/ILoginViewModel.cs
@@ -13,5 +13,6 @@ namespace Hotel_Booking_System.Interfaces
         string Password { get; set; }
         string Email { get; set; }
         bool IsSavedCredentials { get; set; }
+        Task InitializeAsync();
     }
 }

--- a/ViewModels/LoginViewModel.cs
+++ b/ViewModels/LoginViewModel.cs
@@ -34,9 +34,11 @@ namespace Hotel_Booking_System.ViewModels
             _authenticationService = authenticationService;
             _userRepository = userRepository;
             _navigationService = navigationService;
+        }
 
-
-            LoadCredential().Wait();
+        public async Task InitializeAsync()
+        {
+            await LoadCredential();
         }
         [RelayCommand]
         private async Task Login(string email)
@@ -113,33 +115,24 @@ namespace Hotel_Booking_System.ViewModels
         }
         private async Task LoadCredential()
         {
-            try
+            if (!File.Exists("data.json"))
             {
-                if (!File.Exists("data.json"))
-                {
-                    Email = "";
-                    Password = "";
-                    IsSavedCredentials = false;
-                    return;
-                }
+                Email = "";
+                Password = "";
+                IsSavedCredentials = false;
+                return;
+            }
 
-                using (FileStream stream = File.Open("data.json", FileMode.Open))
+            using (FileStream stream = File.Open("data.json", FileMode.Open))
+            {
+                if (stream.Length > 0)
                 {
-                    if (stream.Length > 0)
+                    AutoSave? data = await JsonSerializer.DeserializeAsync<AutoSave>(stream);
+                    if (data != null)
                     {
-                        AutoSave? data = await JsonSerializer.DeserializeAsync<AutoSave>(stream);
-                        if (data != null)
-                        {
-                            Email = data.Email ?? "";
-                            Password = data.Password ?? "";
-                            IsSavedCredentials = data.RememberMe;
-                        }
-                        else
-                        {
-                            Email = "";
-                            Password = "";
-                            IsSavedCredentials = false;
-                        }
+                        Email = data.Email ?? "";
+                        Password = data.Password ?? "";
+                        IsSavedCredentials = data.RememberMe;
                     }
                     else
                     {
@@ -148,12 +141,13 @@ namespace Hotel_Booking_System.ViewModels
                         IsSavedCredentials = false;
                     }
                 }
+                else
+                {
+                    Email = "";
+                    Password = "";
+                    IsSavedCredentials = false;
+                }
             }
-            catch
-            {
-                MessageBox.Show("Không load được tài khoản mật khẩu đã lưu");
-            }
-            
         }
 
 

--- a/Views/LoginWindow.xaml.cs
+++ b/Views/LoginWindow.xaml.cs
@@ -27,10 +27,21 @@ namespace Hotel_Booking_System.Views
         {
             InitializeComponent();
             this.DataContext = _loginViewModel;
-            this.Loaded +=(s,e) => txtPassword.Password = _loginViewModel.Password;
+            this.Loaded += async (s, e) =>
+            {
+                try
+                {
+                    await _loginViewModel.InitializeAsync();
+                }
+                catch
+                {
+                    MessageBox.Show("Không load được tài khoản mật khẩu đã lưu");
+                }
+                txtPassword.Password = _loginViewModel.Password;
+            };
             txtPassword.PasswordChanged += (s, e) =>
             {
-                _loginViewModel.Password = txtPassword.Password;    
+                _loginViewModel.Password = txtPassword.Password;
             };
         }
     }


### PR DESCRIPTION
## Summary
- replace blocking `LoadCredential().Wait()` with async initialization method
- invoke credential loading from `LoginWindow`'s `Loaded` event to keep UI responsive
- expose initialization method on `ILoginViewModel` interface

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4de1a2fc083338c18d151867a04d1