### PR TITLE
Make GetCurrentUser asynchronous in SuperAdminViewModel

### DIFF
--- a/ViewModels/SuperAdminViewModel.cs
+++ b/ViewModels/SuperAdminViewModel.cs
@@ -67,10 +67,10 @@ namespace Hotel_Booking_System.ViewModels
             _userRepository = userRepository;
             _navigationService = navigationService;
 
-            WeakReferenceMessenger.Default.Register<SuperAdminViewModel, MessageService>(this, (recipient, message) =>
+            WeakReferenceMessenger.Default.Register<SuperAdminViewModel, MessageService>(this, async (recipient, message) =>
             {
                 recipient._userEmail = message.Value;
-                GetCurrentUser();
+                await recipient.GetCurrentUserAsync();
 
             });
         }
@@ -101,12 +101,9 @@ namespace Hotel_Booking_System.ViewModels
             }
         }
 
-        private void GetCurrentUser()
+        private async Task GetCurrentUserAsync()
         {
-            Task.Run(async () =>
-            {
-                CurrentUser = await _userRepository.GetByEmailAsync(_userEmail);
-            }).Wait();
+            CurrentUser = await _userRepository.GetByEmailAsync(_userEmail);
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
- Replace blocking Task.Run/Wait with `GetCurrentUserAsync` awaiting `_userRepository.GetByEmailAsync`
- Update messenger registration to await the new async method

## Testing
- `dotnet build Hotel_Booking_System.sln` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e279e3b48333aec0d59848635b2d