### PR TITLE
Add seed data and fix SuperAdmin command bindings

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -27,6 +27,11 @@ namespace Hotel_Booking_System
         {
             base.OnStartup(e);
             Env.Load();
+            using (var scope = Provider?.CreateScope())
+            {
+                var context = scope?.ServiceProvider.GetRequiredService<AppDbContext>();
+                context?.SeedData();
+            }
         }
         private static IServiceProvider? provider;
         public static IServiceProvider? Provider { get => provider ??= ConfigDI(); }

--- a/Services/AppDbContext.cs
+++ b/Services/AppDbContext.cs
@@ -81,6 +81,47 @@ namespace Hotel_Booking_System.Services
 
         }
 
+        public void SeedData()
+        {
+            Database.EnsureCreated();
+
+            if (!Users.Any())
+            {
+                var superAdmin = new User
+                {
+                    FullName = "Super Admin",
+                    Email = "superadmin@example.com",
+                    Password = "123456",
+                    Role = "SuperAdmin",
+                    DateOfBirth = DateTime.Now
+                };
+
+                var requester = new User
+                {
+                    FullName = "Hotel Admin",
+                    Email = "hoteladmin@example.com",
+                    Password = "123456",
+                    Role = "User",
+                    DateOfBirth = DateTime.Now
+                };
+
+                Users.AddRange(superAdmin, requester);
+                SaveChanges();
+
+                HotelAdminRequests.Add(new HotelAdminRequest
+                {
+                    UserID = requester.UserID,
+                    HotelName = "Sample Hotel",
+                    HotelAddress = "123 Sample Street",
+                    Reason = "Initial request",
+                    Status = "Pending",
+                    CreatedAt = DateTime.Now
+                });
+
+                SaveChanges();
+            }
+        }
+
 
     }
 }

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -113,11 +113,11 @@
                                                                Width="45" Height="25" Margin="2" FontSize="10"/>
                                                         <Button Content="✅ Approve" Style="{StaticResource SecondaryButton}"
                                                                Background="#FF4CAF50" Width="55" Height="25" Margin="2" FontSize="10"
-                                                               Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                               Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                CommandParameter="{Binding RequestID}"/>
                                                         <Button Content="❌ Reject" Style="{StaticResource SecondaryButton}"
                                                                Background="#FFFF5722" Width="50" Height="25" Margin="2" FontSize="10"
-                                                               Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                               Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                CommandParameter="{Binding RequestID}"/>
                                                     </StackPanel>
                                                 </DataTemplate>
@@ -701,8 +701,8 @@
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
-                                            <Button Content="Approve" Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding RequestID}" Margin="2"/>
-                                            <Button Content="Reject" Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding RequestID}" Margin="2"/>
+                                            <Button Content="Approve" Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" CommandParameter="{Binding RequestID}" Margin="2"/>
+                                            <Button Content="Reject" Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" CommandParameter="{Binding RequestID}" Margin="2"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- Seed initial users and a pending hotel admin request in `AppDbContext`
- Seed data automatically on application startup
- Correct `RelativeSource` bindings for SuperAdmin approve/reject buttons

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e83992788333b57cfc56a6dbdc1c