### PR TITLE
Prevent null DialogResult crashes in dialogs

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -98,7 +98,7 @@ namespace Hotel_Booking_System.Services
             
             bookingWindow.DataContext = vm;
             bookingWindow.ShowDialog();
-            return (bool)bookingWindow.DialogResult!;
+            return bookingWindow.DialogResult == true;
             
         }
         public void CloseBookingDialog()
@@ -121,7 +121,7 @@ namespace Hotel_Booking_System.Services
 
             reviewWindow.DataContext = vm;
             reviewWindow.ShowDialog();
-            return (bool)reviewWindow.DialogResult!;
+            return reviewWindow.DialogResult == true;
         }
 
 
@@ -141,7 +141,7 @@ namespace Hotel_Booking_System.Services
             vm.TotalPayment = amount;
             paymentWindow.DataContext = vm;
             paymentWindow.ShowDialog();
-            return (bool)paymentWindow.DialogResult!;
+            return paymentWindow.DialogResult == true;
         }
         public void ClosePaymentDialog()
         {


### PR DESCRIPTION
## Summary
- Safely handle nullable `DialogResult` when closing Booking, Review, and Payment dialogs
- Return `false` if a dialog closes without explicit confirmation

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ede7f4448333b2bde5ac26d2c304