### PR TITLE
Fix payment dialog closing issue

### DIFF
--- a/ViewModels/BookingViewModel.cs
+++ b/ViewModels/BookingViewModel.cs
@@ -99,7 +99,6 @@ namespace Hotel_Booking_System.ViewModels
             await _bookingRepository.AddAsync(booking);
             await _bookingRepository.SaveAsync();
 
-            _navigationService.CloseBookingDialog();
             _navigationService.OpenPaymentDialog(booking.BookingID, TotalPayment);
         }
     }


### PR DESCRIPTION
## Summary
- Prevent main window from closing before opening payment dialog

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f07207fc833393b27060e7abcea1