### PR TITLE
Fix booking actions and update cancellation flow

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -49,6 +49,7 @@ namespace Hotel_Booking_System
                 .AddTransient<ForgotPasswordWindow>()
                 .AddTransient<UserWindow>()
                 .AddTransient<BookingDialog>()
+                .AddTransient<ModifyBookingDialog>()
                 .AddTransient<SignUpWindow>()
                 .AddTransient<SuperAdminWindow>()
                 .AddTransient<ReviewDialog>()

--- a/Interfaces/INavigationService.cs
+++ b/Interfaces/INavigationService.cs
@@ -55,5 +55,6 @@ namespace Hotel_Booking_System.Interfaces
     {
         void NavigateToHotel();
         bool OpenReviewDialog(Booking booking);
+        bool OpenModifyDialog(Booking booking);
     }
 }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -143,6 +143,22 @@ namespace Hotel_Booking_System.Services
             paymentWindow.ShowDialog();
             return paymentWindow.DialogResult == true;
         }
+
+        public bool OpenModifyDialog(Booking booking)
+        {
+            var modifyWindow = App.Provider!.GetRequiredService<ModifyBookingDialog>();
+
+            modifyWindow.btnCancel.Click += (s, e) =>
+            {
+                modifyWindow.DialogResult = false;
+                modifyWindow.Close();
+            };
+            modifyWindow.btnSave.Click += (s, e) => modifyWindow.DialogResult = true;
+
+            modifyWindow.DataContext = booking;
+            modifyWindow.ShowDialog();
+            return modifyWindow.DialogResult == true;
+        }
         public void ClosePaymentDialog()
         {
             CloseCurrent();

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -514,19 +514,42 @@ namespace Hotel_Booking_System.ViewModels
         [RelayCommand]
         private void ReviewBooking(Booking booking)
         {
+            if (booking == null)
+                return;
+
+            // Only allow review after checkout date
+            if (DateTime.Now < booking.CheckOutDate)
+            {
+                MessageBox.Show("You can only review after your stay has completed.", "Review not available", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             bool res = _navigationService.OpenReviewDialog(booking);
             if (res)
             {
                 LoadReviewsForHotel(booking.HotelID);
             }
         }
-        
+
+        [RelayCommand]
         private async Task CancelBooking(Booking booking)
         {
             if (booking == null)
                 return;
 
-            booking.Status = "Cancelled";
+            if (booking.Status == "Confirmed")
+            {
+                // Send cancellation request to hotel admin
+                booking.Status = "CancelRequested";
+                MessageBox.Show("Cancellation request sent to hotel admin.", "Request sent", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else if (booking.Status == "Pending")
+            {
+                // Cancel immediately if booking has not been confirmed yet
+                booking.Status = "Cancelled";
+                MessageBox.Show("Booking cancelled successfully.", "Cancelled", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+
             await _bookingRepository.UpdateAsync(booking);
             FilterBookingsByUser(CurrentUser.UserID);
         }
@@ -537,8 +560,22 @@ namespace Hotel_Booking_System.ViewModels
             if (booking == null)
                 return;
 
-            booking.Status = "Modified";
-            await _bookingRepository.UpdateAsync(booking);
+            if (booking.Status == "Confirmed")
+            {
+                booking.Status = "ModifyRequested";
+                MessageBox.Show("Modification request sent to hotel admin.", "Request sent", MessageBoxButton.OK, MessageBoxImage.Information);
+                await _bookingRepository.UpdateAsync(booking);
+            }
+            else if (booking.Status == "Pending")
+            {
+                bool res = _navigationService.OpenModifyDialog(booking);
+                if (res)
+                {
+                    booking.Status = "Modified";
+                    await _bookingRepository.UpdateAsync(booking);
+                }
+            }
+
             FilterBookingsByUser(CurrentUser.UserID);
         }
         

--- a/Views/ModifyBookingDialog.xaml
+++ b/Views/ModifyBookingDialog.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="Hotel_Booking_System.Views.ModifyBookingDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Modify Booking"
+        Height="250" Width="350"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
+        Background="Transparent"
+        WindowStyle="None"
+        AllowsTransparency="True">
+    <Border CornerRadius="20"
+            Background="White"
+            Padding="20"
+            SnapsToDevicePixels="True">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Text="Modify Booking"
+                       FontSize="18" FontWeight="Bold"
+                       Foreground="#2C3E50"
+                       HorizontalAlignment="Center"
+                       Margin="0,0,0,20"/>
+
+            <StackPanel Grid.Row="1" Margin="0,5">
+                <TextBlock Text="Check-in Date" FontSize="12" Foreground="#7F8C8D"/>
+                <DatePicker SelectedDate="{Binding CheckInDate}" Height="32" BorderBrush="#BDC3C7" BorderThickness="1"/>
+            </StackPanel>
+
+            <StackPanel Grid.Row="2" Margin="0,5">
+                <TextBlock Text="Check-out Date" FontSize="12" Foreground="#7F8C8D"/>
+                <DatePicker SelectedDate="{Binding CheckOutDate}" Height="32" BorderBrush="#BDC3C7" BorderThickness="1"/>
+            </StackPanel>
+
+            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                <Button Content="Cancel" Width="90" Height="36"
+                        x:Name="btnCancel"
+                        Background="#ECF0F1" Foreground="#2C3E50"
+                        BorderBrush="{x:Null}" Margin="0,0,10,0"/>
+                <Button Content="Save" Width="90" Height="36"
+                        x:Name="btnSave"
+                        Background="#27AE60" Foreground="White" FontWeight="Bold" BorderBrush="{x:Null}"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/Views/ModifyBookingDialog.xaml.cs
+++ b/Views/ModifyBookingDialog.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Hotel_Booking_System.Views
+{
+    public partial class ModifyBookingDialog : Window
+    {
+        public ModifyBookingDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable Booking List action buttons by exposing CancelBooking as a RelayCommand
- request hotel-admin cancellation for confirmed bookings and auto-cancel pending ones
- block reviews until after checkout
- add status-aware booking modification that requests admin approval when confirmed and opens a dialog for pending edits

## Testing
- `dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68c4f6efd1cc83338228e0592badf15c