### PR TITLE
Refine booking modification flow and add admin processing

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -49,6 +49,7 @@ namespace Hotel_Booking_System
                 .AddTransient<ForgotPasswordWindow>()
                 .AddTransient<UserWindow>()
                 .AddTransient<BookingDialog>()
+                .AddTransient<ModifyBookingDialog>()
                 .AddTransient<SignUpWindow>()
                 .AddTransient<SuperAdminWindow>()
                 .AddTransient<ReviewDialog>()

--- a/Interfaces/INavigationService.cs
+++ b/Interfaces/INavigationService.cs
@@ -55,5 +55,6 @@ namespace Hotel_Booking_System.Interfaces
     {
         void NavigateToHotel();
         bool OpenReviewDialog(Booking booking);
+        bool OpenModifyDialog(Booking booking);
     }
 }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -143,6 +143,22 @@ namespace Hotel_Booking_System.Services
             paymentWindow.ShowDialog();
             return paymentWindow.DialogResult == true;
         }
+
+        public bool OpenModifyDialog(Booking booking)
+        {
+            var modifyWindow = App.Provider!.GetRequiredService<ModifyBookingDialog>();
+
+            modifyWindow.btnCancel.Click += (s, e) =>
+            {
+                modifyWindow.DialogResult = false;
+                modifyWindow.Close();
+            };
+            modifyWindow.btnSave.Click += (s, e) => modifyWindow.DialogResult = true;
+
+            modifyWindow.DataContext = booking;
+            modifyWindow.ShowDialog();
+            return modifyWindow.DialogResult == true;
+        }
         public void ClosePaymentDialog()
         {
             CloseCurrent();

--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -171,6 +171,34 @@ namespace Hotel_Booking_System.ViewModels
             await _roomRepository.SaveAsync();
             LoadRooms();
         }
+
+        [RelayCommand]
+        private async Task ConfirmBooking(Booking? booking)
+        {
+            if (booking == null)
+                return;
+
+            if (booking.Status == "Pending")
+            {
+                booking.Status = "Confirmed";
+                await _bookingRepository.UpdateAsync(booking);
+                LoadBookings();
+            }
+        }
+
+        [RelayCommand]
+        private async Task CancelBooking(Booking? booking)
+        {
+            if (booking == null)
+                return;
+
+            if (booking.Status == "Pending" || booking.Status == "CancelRequested")
+            {
+                booking.Status = "Cancelled";
+                await _bookingRepository.UpdateAsync(booking);
+                LoadBookings();
+            }
+        }
     }
 }
 

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -514,19 +514,42 @@ namespace Hotel_Booking_System.ViewModels
         [RelayCommand]
         private void ReviewBooking(Booking booking)
         {
+            if (booking == null)
+                return;
+
+            // Only allow review after checkout date
+            if (DateTime.Now < booking.CheckOutDate)
+            {
+                MessageBox.Show("You can only review after your stay has completed.", "Review not available", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             bool res = _navigationService.OpenReviewDialog(booking);
             if (res)
             {
                 LoadReviewsForHotel(booking.HotelID);
             }
         }
-        
+
+        [RelayCommand]
         private async Task CancelBooking(Booking booking)
         {
             if (booking == null)
                 return;
 
-            booking.Status = "Cancelled";
+            if (booking.Status == "Confirmed")
+            {
+                // Send cancellation request to hotel admin
+                booking.Status = "CancelRequested";
+                MessageBox.Show("Cancellation request sent to hotel admin.", "Request sent", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else if (booking.Status == "Pending")
+            {
+                // Cancel immediately if booking has not been confirmed yet
+                booking.Status = "Cancelled";
+                MessageBox.Show("Booking cancelled successfully.", "Cancelled", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+
             await _bookingRepository.UpdateAsync(booking);
             FilterBookingsByUser(CurrentUser.UserID);
         }
@@ -537,8 +560,27 @@ namespace Hotel_Booking_System.ViewModels
             if (booking == null)
                 return;
 
-            booking.Status = "Modified";
-            await _bookingRepository.UpdateAsync(booking);
+            if (booking.Status == "Confirmed")
+            {
+                bool res = _navigationService.OpenModifyDialog(booking);
+                if (res)
+                {
+                    // After modification a confirmed booking becomes pending again for admin approval
+                    booking.Status = "Pending";
+                    MessageBox.Show("Modification request sent to hotel admin.", "Request sent", MessageBoxButton.OK, MessageBoxImage.Information);
+                    await _bookingRepository.UpdateAsync(booking);
+                }
+            }
+            else if (booking.Status == "Pending")
+            {
+                bool res = _navigationService.OpenModifyDialog(booking);
+                if (res)
+                {
+                    // Pending bookings can be modified directly
+                    await _bookingRepository.UpdateAsync(booking);
+                }
+            }
+
             FilterBookingsByUser(CurrentUser.UserID);
         }
         

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -208,25 +208,53 @@
   
                         <Border Style="{StaticResource CardStyle}">
                             <StackPanel Margin="25">
-                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False">
+                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding Bookings}">
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Booking ID" Width="120" Binding="{Binding BookingId}"/>
-                                        <DataGridTextColumn Header="Guest Name" Width="150" Binding="{Binding GuestName}"/>
-                                        <DataGridTextColumn Header="Room" Width="80" Binding="{Binding Room}"/>
-                                        <DataGridTextColumn Header="Check-in" Width="100" Binding="{Binding CheckIn}"/>
-                                        <DataGridTextColumn Header="Check-out" Width="100" Binding="{Binding CheckOut}"/>
+                                        <DataGridTextColumn Header="Booking ID" Width="120" Binding="{Binding BookingID}"/>
+                                        <DataGridTextColumn Header="Guest Name" Width="150" Binding="{Binding UserID}"/>
+                                        <DataGridTextColumn Header="Room" Width="80" Binding="{Binding RoomID}"/>
+                                        <DataGridTextColumn Header="Check-in" Width="100" Binding="{Binding CheckInDate}"/>
+                                        <DataGridTextColumn Header="Check-out" Width="100" Binding="{Binding CheckOutDate}"/>
                                         <DataGridTextColumn Header="Status" Width="100" Binding="{Binding Status}"/>
-                                        <DataGridTextColumn Header="Total" Width="100" Binding="{Binding Total}"/>
                                         <DataGridTemplateColumn Header="Actions" Width="200">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
-                                                        <Button Content="Confirm" Style="{StaticResource SecondaryButton}" 
-                                                           Background="#FF4CAF50" Width="60" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content= "Cancel" Style="{StaticResource SecondaryButton}" 
-                                                           Background="#FFFF5722" Width="60" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="Email" Style="{StaticResource SecondaryButton}" 
-                                                           Background="#FF2196F3" Width="50" Height="25" Margin="2" FontSize="10"/>
+                                                        <Button Width="60" Height="25" Margin="2" FontSize="10" Background="#FF4CAF50"
+                                                            Command="{Binding DataContext.ConfirmBookingCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                            CommandParameter="{Binding}">
+                                                            <Button.Style>
+                                                                <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Setter Property="Content" Value="Confirm"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Pending">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Button.Style>
+                                                        </Button>
+                                                        <Button Width="80" Height="25" Margin="2" FontSize="10" Background="#FFFF5722"
+                                                            Command="{Binding DataContext.CancelBookingCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                            CommandParameter="{Binding}">
+                                                            <Button.Style>
+                                                                <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Setter Property="Content" Value="Cancel"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Pending">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                            <Setter Property="Content" Value="Cancel"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="CancelRequested">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                            <Setter Property="Content" Value="Approve Cancel"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Button.Style>
+                                                        </Button>
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </DataGridTemplateColumn.CellTemplate>

--- a/Views/ModifyBookingDialog.xaml
+++ b/Views/ModifyBookingDialog.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="Hotel_Booking_System.Views.ModifyBookingDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Modify Booking"
+        Height="250" Width="350"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
+        Background="Transparent"
+        WindowStyle="None"
+        AllowsTransparency="True">
+    <Border CornerRadius="20"
+            Background="White"
+            Padding="20"
+            SnapsToDevicePixels="True">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Text="Modify Booking"
+                       FontSize="18" FontWeight="Bold"
+                       Foreground="#2C3E50"
+                       HorizontalAlignment="Center"
+                       Margin="0,0,0,20"/>
+
+            <StackPanel Grid.Row="1" Margin="0,5">
+                <TextBlock Text="Check-in Date" FontSize="12" Foreground="#7F8C8D"/>
+                <DatePicker SelectedDate="{Binding CheckInDate}" Height="32" BorderBrush="#BDC3C7" BorderThickness="1"/>
+            </StackPanel>
+
+            <StackPanel Grid.Row="2" Margin="0,5">
+                <TextBlock Text="Check-out Date" FontSize="12" Foreground="#7F8C8D"/>
+                <DatePicker SelectedDate="{Binding CheckOutDate}" Height="32" BorderBrush="#BDC3C7" BorderThickness="1"/>
+            </StackPanel>
+
+            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                <Button Content="Cancel" Width="90" Height="36"
+                        x:Name="btnCancel"
+                        Background="#ECF0F1" Foreground="#2C3E50"
+                        BorderBrush="{x:Null}" Margin="0,0,10,0"/>
+                <Button Content="Save" Width="90" Height="36"
+                        x:Name="btnSave"
+                        Background="#27AE60" Foreground="White" FontWeight="Bold" BorderBrush="{x:Null}"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/Views/ModifyBookingDialog.xaml.cs
+++ b/Views/ModifyBookingDialog.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Hotel_Booking_System.Views
+{
+    public partial class ModifyBookingDialog : Window
+    {
+        public ModifyBookingDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mark confirmed bookings as pending when edited and allow pending bookings to update directly
- let hotel admins confirm or cancel bookings and surface action buttons in the booking management UI

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: command not found: dotnet)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f6efd1cc83338228e0592badf15c