### PR TITLE
Add typing animation to chat responses

### DIFF
--- a/DomainModels/AIChat.cs
+++ b/DomainModels/AIChat.cs
@@ -1,19 +1,46 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Hotel_Manager.FrameWorks;
 
 namespace Hotel_Booking_System.DomainModels
 {
-    public class AIChat
+    public class AIChat : Bindable
     {
         [Key]
         public string ChatID {  get; set; }
         public string UserID { get; set; }
         public string Message { get; set; }
-        public string Response { get; set; }
+
+        private string _response;
+        public string Response
+        {
+            get => _response;
+            set => Set(ref _response, value);
+        }
+
         public DateTime CreatedAt { get; set; }
+
+        [NotMapped]
+        private bool _isTyping;
+        [NotMapped]
+        public bool IsTyping
+        {
+            get => _isTyping;
+            set => Set(ref _isTyping, value);
+        }
+
+        [NotMapped]
+        private string _typingIndicator = string.Empty;
+        [NotMapped]
+        public string TypingIndicator
+        {
+            get => _typingIndicator;
+            set => Set(ref _typingIndicator, value);
+        }
     }
 }

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -603,11 +603,23 @@
 
                                                         <Border Grid.Column="1" HorizontalAlignment="Left" Background="#FFE8F5E8"
                     CornerRadius="12" Margin="0,0,0,0" Padding="12">
-                                                            <TextBlock Text="{Binding Response}" TextWrapping="Wrap" FontSize="12"
-                           MaxWidth="220"/>
+                                                            <Grid>
+                                                                <TextBlock x:Name="ResponseText" Text="{Binding Response}" TextWrapping="Wrap" FontSize="12" MaxWidth="220"/>
+                                                                <TextBlock x:Name="TypingText" Text="{Binding TypingIndicator}" FontSize="12" MaxWidth="220" Visibility="Collapsed"/>
+                                                            </Grid>
                                                         </Border>
                                                     </Grid>
                                                 </StackPanel>
+                                                <DataTemplate.Triggers>
+                                                    <DataTrigger Binding="{Binding IsTyping}" Value="True">
+                                                        <Setter TargetName="ResponseText" Property="Visibility" Value="Collapsed"/>
+                                                        <Setter TargetName="TypingText" Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsTyping}" Value="False">
+                                                        <Setter TargetName="ResponseText" Property="Visibility" Value="Visible"/>
+                                                        <Setter TargetName="TypingText" Property="Visibility" Value="Collapsed"/>
+                                                    </DataTrigger>
+                                                </DataTemplate.Triggers>
                                             </DataTemplate>
 
                                         </ListBox.ItemTemplate>


### PR DESCRIPTION
## Summary
- Animate AI responses letter by letter and show typing indicator
- Support chat typing animation in UI with data triggers
- Introduce bindable AIChat model with typing state

## Testing
- `dotnet build` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c529b418748333b290eb49afd81af4