### PR TITLE
fix: enable smooth chat scrolling

### DIFF
--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -554,7 +554,7 @@
                                     </StackPanel>
                                 </Border>
 
-                                <ListBox Grid.Row="1" Margin="15" bh:ListBoxExtensions.AutoScroll="True" ItemsSource="{Binding Chats}" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                <ListBox Grid.Row="1" Margin="15" bh:ListBoxExtensions.AutoScroll="True" ItemsSource="{Binding Chats}" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="False">
                                         <ListBox.ItemContainerStyle>
                                             <Style TargetType="ListBoxItem">
                                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>


### PR DESCRIPTION
## Summary
- enable pixel-based scrolling in chat list for smoother motion

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53a8cf2d08333b86720074b1e5c51