### PR TITLE
Display reviewer info in hotel reviews

### DIFF
--- a/DomainModels/Review.cs
+++ b/DomainModels/Review.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,5 +19,11 @@ namespace Hotel_Booking_System.DomainModels
         public int Rating { get; set; }
         public string Comment { get; set; }
         public DateTime CreatedAt { get; set; }
+
+        [NotMapped]
+        public string ReviewerName { get; set; } = string.Empty;
+
+        [NotMapped]
+        public string ReviewerAvatarUrl { get; set; } = string.Empty;
     }
 }

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -764,6 +764,12 @@ namespace Hotel_Booking_System.ViewModels
             var hotelReviews = reviewList.Where(r => r.HotelID == hotelId).ToList();
             foreach (var review in hotelReviews)
             {
+                var user = _userRepository.GetByIdAsync(review.UserID).Result;
+                if (user != null)
+                {
+                    review.ReviewerName = user.FullName;
+                    review.ReviewerAvatarUrl = user.AvatarUrl;
+                }
                 Reviews.Add(review);
             }
         }

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -324,9 +324,13 @@
                                         <ListView.ItemTemplate>
                                             <DataTemplate>
                                                 <Border BorderBrush="#FFE0E0E0" BorderThickness="0,0,0,1" Padding="0,10">
-                                                    <StackPanel>
-                                                        <TextBlock Text="{Binding Rating, StringFormat='Rating: {0}'}" FontWeight="Bold"/>
-                                                        <TextBlock Text="{Binding Comment}" TextWrapping="Wrap"/>
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <Image Source="{Binding ReviewerAvatarUrl}" Width="40" Height="40" Margin="0,0,10,0"/>
+                                                        <StackPanel>
+                                                            <TextBlock Text="{Binding ReviewerName}" FontWeight="Bold"/>
+                                                            <TextBlock Text="{Binding Rating, StringFormat='Rating: {0}'}"/>
+                                                            <TextBlock Text="{Binding Comment}" TextWrapping="Wrap"/>
+                                                        </StackPanel>
                                                     </StackPanel>
                                                 </Border>
                                             </DataTemplate>


### PR DESCRIPTION
## Summary
- add reviewer name and avatar fields to reviews
- load reviewer details when fetching hotel reviews
- show reviewer avatar, name, rating, and comment in user UI

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5968a9c1c8333af91cef0aff1e347