### PR TITLE
Implement password change in UserWindow

### DIFF
--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -886,6 +886,7 @@
                             <Border Style="{StaticResource CardStyle}">
                                 <StackPanel Margin="25">
                                     <TextBlock Text="Change Password" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                                    <TextBlock Text="{Binding NotificationMessage}" Foreground="Red" FontSize="14" HorizontalAlignment="Center" Margin="0,0,0,10"/>
 
                                     <Grid>
                                         <Grid.ColumnDefinitions>
@@ -933,7 +934,7 @@
                                     </Grid>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
-                                        <Button Content="Change Password" Width="150" Style="{StaticResource PrimaryButton}" 
+                                        <Button Command="{Binding ChangePasswordCommand}" Content="Change Password" Width="150" Style="{StaticResource PrimaryButton}"
                                     Background="#FFFF5722" Margin="0,0,10,0"/>
                                         <Button Content="Cancel" Width="100" Style="{StaticResource SecondaryButton}"/>
                                     </StackPanel>

--- a/Views/UserWindow.xaml.cs
+++ b/Views/UserWindow.xaml.cs
@@ -25,8 +25,19 @@ namespace Hotel_Booking_System.Views
             InitializeComponent();
             DataContext = _userViewModel;
 
-           
-            
+            txtCurrentPassword.PasswordChanged += (s, e) =>
+            {
+                (_userViewModel as dynamic).CurrentPassword = txtCurrentPassword.Password;
+            };
+            txtNewPassword.PasswordChanged += (s, e) =>
+            {
+                (_userViewModel as dynamic).NewPassword = txtNewPassword.Password;
+            };
+            txtConfirmPassword.PasswordChanged += (s, e) =>
+            {
+                (_userViewModel as dynamic).ConfirmPassword = txtConfirmPassword.Password;
+            };
+
         }
 
         


### PR DESCRIPTION
## Summary
- add notification message property and timer to user view model for inline password change feedback
- show password change validation errors and success via inline notification instead of modal dialogs
- display notification text in UserWindow change password section

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68706ff548333a44592becadbb0cb