### PR TITLE
Add user rating filter for hotel search

### DIFF
--- a/Converters/FilterHotelConverter.cs
+++ b/Converters/FilterHotelConverter.cs
@@ -33,6 +33,9 @@ namespace Hotel_Booking_System.Converters
             bool? freeParking = values[10] as bool?;
             bool? restaurant = values[11] as bool?;
             bool? gym = values[12] as bool?;
+            double? userRating = null;
+            if (values.Length > 13 && double.TryParse(values[13]?.ToString(), out var ur))
+                userRating = ur;
 
             var filterDict = new Dictionary<string, object?>
             {
@@ -48,7 +51,8 @@ namespace Hotel_Booking_System.Converters
                 { "SwimmingPool", swimmingPool },
                 { "FreeParking", freeParking },
                 { "Restaurant", restaurant },
-                { "Gym", gym }
+                { "Gym", gym },
+                { "UserRating", userRating }
             };
 
             return filterDict;

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -369,6 +369,7 @@ namespace Hotel_Booking_System.ViewModels
                 bool? freeParking = searchParams.TryGetValue("FreeParking", out var parking) ? parking as bool? : null;
                 bool? restaurant = searchParams.TryGetValue("Restaurant", out var rest) ? rest as bool? : null;
                 bool? gym = searchParams.TryGetValue("Gym", out var gymVal) ? gymVal as bool? : null;
+                double? userRating = searchParams.TryGetValue("UserRating", out var ur) && ur is double dur ? dur : null;
 
 
                 List<Hotel> hotels = _hotelRepository.GetAllAsync().Result
@@ -395,7 +396,10 @@ namespace Hotel_Booking_System.ViewModels
                 if (twoStar == true) starFilters.Add(2);
                 if (oneStar == true) starFilters.Add(1);
                 if (starFilters.Count > 0)
-                    hotels = hotels.Where(h => starFilters.Contains((int)Math.Round(h.AverageRating))).ToList();
+                    hotels = hotels.Where(h => starFilters.Contains(h.Rating)).ToList();
+
+                if (userRating.HasValue)
+                    hotels = hotels.Where(h => h.AverageRating >= userRating.Value).ToList();
 
                 if (freeWifi == true)
                     hotels = hotels.Where(h => h.Amenities.Any(a => a.AmenityName == "Free WiFi")).ToList();

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -130,6 +130,11 @@
                                             </StackPanel>
                                         </Border>
 
+                                        <TextBlock Text="User Rating" FontWeight="SemiBold" Margin="0,0,0,10"/>
+                                        <Border Background="#FFF8F9FA" CornerRadius="8" Padding="15,12" Margin="0,0,0,20">
+                                            <TextBox x:Name="txtUserRating" Width="80" Height="30" HorizontalAlignment="Left"/>
+                                        </Border>
+
                                         <TextBlock Text="Amenities" FontWeight="SemiBold" Margin="0,0,0,10"/>
                                         <Border Background="#FFF8F9FA" CornerRadius="8" Padding="15,12" Margin="0,0,0,20">
                                             <StackPanel>
@@ -157,6 +162,7 @@
                                                     <Binding ElementName="cbFreeParking" Path="IsChecked"/>
                                                     <Binding ElementName="cbRestaurant" Path="IsChecked"/>
                                                     <Binding ElementName="cbGym" Path="IsChecked"/>
+                                                    <Binding ElementName="txtUserRating" Path="Text"/>
                                                 </MultiBinding>
                                             </Button.CommandParameter>
                                         </Button>


### PR DESCRIPTION
## Summary
- enable filtering hotels by minimum user rating
- correct star rating filter to use hotel star values
- expose user rating field in hotel filter UI

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68a51d6ec8333a61e6cf8b99e13b1