### PR TITLE
Expose hotel admin commands

### DIFF
--- a/Interfaces/IHotelAdminViewModel.cs
+++ b/Interfaces/IHotelAdminViewModel.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.Input;
 using Hotel_Booking_System.DomainModels;
 
 namespace Hotel_Booking_System.Interfaces
@@ -15,14 +14,6 @@ namespace Hotel_Booking_System.Interfaces
         ObservableCollection<Booking> Bookings { get; }
         ObservableCollection<Review> Reviews { get; }
         User CurrentUser { get; set; }
-
-        IRelayCommand NewHotelCommand { get; }
-        IAsyncRelayCommand UpdateHotelInfoCommand { get; }
-        IAsyncRelayCommand AddRoomCommand { get; }
-        IAsyncRelayCommand<Room?> EditRoomCommand { get; }
-        IAsyncRelayCommand<Room?> RemoveRoomCommand { get; }
-        IAsyncRelayCommand<Booking?> ConfirmBookingCommand { get; }
-        IAsyncRelayCommand<Booking?> CancelBookingCommand { get; }
 
         Task LoadReviewsAsync();
     }

--- a/Interfaces/IHotelAdminViewModel.cs
+++ b/Interfaces/IHotelAdminViewModel.cs
@@ -1,12 +1,13 @@
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Hotel_Booking_System.DomainModels;
 
 namespace Hotel_Booking_System.Interfaces
 {
 
        
-    interface IHotelAdminViewModel
+    public interface IHotelAdminViewModel
     {
         ObservableCollection<Hotel> Hotels { get; }
         Hotel? CurrentHotel { get; set; }
@@ -14,6 +15,15 @@ namespace Hotel_Booking_System.Interfaces
         ObservableCollection<Booking> Bookings { get; }
         ObservableCollection<Review> Reviews { get; }
         User CurrentUser { get; set; }
+
+        ICommand NewHotelCommand { get; }
+        ICommand UpdateHotelInfoCommand { get; }
+        ICommand AddRoomCommand { get; }
+        ICommand EditRoomCommand { get; }
+        ICommand RemoveRoomCommand { get; }
+        ICommand ConfirmBookingCommand { get; }
+        ICommand CancelBookingCommand { get; }
+
         Task LoadReviewsAsync();
     }
 }

--- a/Interfaces/IHotelAdminViewModel.cs
+++ b/Interfaces/IHotelAdminViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using Hotel_Booking_System.DomainModels;
 
 namespace Hotel_Booking_System.Interfaces
@@ -16,13 +16,13 @@ namespace Hotel_Booking_System.Interfaces
         ObservableCollection<Review> Reviews { get; }
         User CurrentUser { get; set; }
 
-        ICommand NewHotelCommand { get; }
-        ICommand UpdateHotelInfoCommand { get; }
-        ICommand AddRoomCommand { get; }
-        ICommand EditRoomCommand { get; }
-        ICommand RemoveRoomCommand { get; }
-        ICommand ConfirmBookingCommand { get; }
-        ICommand CancelBookingCommand { get; }
+        IRelayCommand NewHotelCommand { get; }
+        IAsyncRelayCommand UpdateHotelInfoCommand { get; }
+        IAsyncRelayCommand AddRoomCommand { get; }
+        IAsyncRelayCommand<Room?> EditRoomCommand { get; }
+        IAsyncRelayCommand<Room?> RemoveRoomCommand { get; }
+        IAsyncRelayCommand<Booking?> ConfirmBookingCommand { get; }
+        IAsyncRelayCommand<Booking?> CancelBookingCommand { get; }
 
         Task LoadReviewsAsync();
     }


### PR DESCRIPTION
## Summary
- expose hotel admin commands in the view model interface so WPF bindings can locate them

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6964584148333b8e1e8c1f4e0c4da