### PR TITLE
Add hotel and room image upload for admins

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -54,6 +54,7 @@ namespace Hotel_Booking_System
                 .AddTransient<SuperAdminWindow>()
                 .AddTransient<ReviewDialog>()
                 .AddTransient<PaymentDialog>()
+                .AddTransient<EditRoomDialog>()
                 .AddTransient<HotelAdminWindow>()
                 .AddScoped<IHotelRepository, HotelRepository>()
                 .AddSingleton<IBookingRepository, BookingRepository>()

--- a/Views/EditRoomDialog.xaml
+++ b/Views/EditRoomDialog.xaml
@@ -1,0 +1,23 @@
+<Window x:Class="Hotel_Booking_System.Views.EditRoomDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Edit Room" Height="450" Width="400" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="20">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,15">
+            <Image Source="{Binding RoomImage}" Width="120" Height="80"/>
+            <Button Content="Upload Image" Margin="10,0,0,0" Click="UploadImage_Click"/>
+        </StackPanel>
+        <TextBlock Text="Room Number"/>
+        <TextBox Text="{Binding RoomNumber}" Margin="0,0,0,10"/>
+        <TextBlock Text="Room Type"/>
+        <TextBox Text="{Binding RoomType}" Margin="0,0,0,10"/>
+        <TextBlock Text="Capacity"/>
+        <TextBox Text="{Binding Capacity}" Margin="0,0,0,10"/>
+        <TextBlock Text="Price per Night"/>
+        <TextBox Text="{Binding PricePerNight}" Margin="0,0,0,20"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="btnSave" Content="Save" Width="80" Margin="5" Click="Save_Click"/>
+            <Button x:Name="btnCancel" Content="Cancel" Width="80" Margin="5" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Views/EditRoomDialog.xaml.cs
+++ b/Views/EditRoomDialog.xaml.cs
@@ -1,0 +1,40 @@
+using System.Windows;
+using Microsoft.Win32;
+using Hotel_Booking_System.Services;
+using Hotel_Booking_System.DomainModels;
+
+namespace Hotel_Booking_System.Views
+{
+    public partial class EditRoomDialog : Window
+    {
+        public EditRoomDialog()
+        {
+            InitializeComponent();
+        }
+
+        private async void UploadImage_Click(object sender, RoutedEventArgs e)
+        {
+            FileDialog openFileDialog = new OpenFileDialog();
+            openFileDialog.Filter = "Image files (*.png;*.jpeg;*.jpg)|*.png;*.jpeg;*.jpg";
+            if (openFileDialog.ShowDialog() == true)
+            {
+                if (DataContext is Room room)
+                {
+                    room.RoomImage = await UploadImageService.UploadAsync(openFileDialog.FileName);
+                }
+            }
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -93,6 +93,12 @@
                                             Command="{Binding NewHotelCommand}"/>
                                 </StackPanel>
 
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,15">
+                                    <Image Source="{Binding CurrentHotel.HotelImage}" Width="150" Height="100"/>
+                                    <Button Content="Upload Image" Style="{StaticResource PrimaryButton}" Margin="10,0,0,0"
+                                            Command="{Binding UploadHotelImageCommand}"/>
+                                </StackPanel>
+
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>


### PR DESCRIPTION
## Summary
- Allow hotel admins to upload a main hotel image
- Provide an edit room dialog to update room info and upload room images
- Register new dialog in DI for use in view model

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c69c8acfcc833393b12bf7f7c0f08d