### PR TITLE
Bind review rating bars to statistics

### DIFF
--- a/Interfaces/IHotelAdminViewModel.cs
+++ b/Interfaces/IHotelAdminViewModel.cs
@@ -15,6 +15,21 @@ namespace Hotel_Booking_System.Interfaces
         ObservableCollection<Review> Reviews { get; }
         User CurrentUser { get; set; }
 
+        int TotalReviews { get; }
+        double AverageRating { get; }
+
+        int FiveStarCount { get; }
+        int FourStarCount { get; }
+        int ThreeStarCount { get; }
+        int TwoStarCount { get; }
+        int OneStarCount { get; }
+
+        double FiveStarRatio { get; }
+        double FourStarRatio { get; }
+        double ThreeStarRatio { get; }
+        double TwoStarRatio { get; }
+        double OneStarRatio { get; }
+
         Task LoadReviewsAsync();
     }
 }

--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -53,6 +53,61 @@ namespace Hotel_Booking_System.ViewModels
             set => Set(ref _currentUser, value);
         }
 
+        private int _totalReviews;
+        public int TotalReviews
+        {
+            get => _totalReviews;
+            private set => Set(ref _totalReviews, value);
+        }
+
+        private double _averageRating;
+        public double AverageRating
+        {
+            get => _averageRating;
+            private set => Set(ref _averageRating, value);
+        }
+
+        private int _fiveStarCount;
+        public int FiveStarCount
+        {
+            get => _fiveStarCount;
+            private set => Set(ref _fiveStarCount, value);
+        }
+
+        private int _fourStarCount;
+        public int FourStarCount
+        {
+            get => _fourStarCount;
+            private set => Set(ref _fourStarCount, value);
+        }
+
+        private int _threeStarCount;
+        public int ThreeStarCount
+        {
+            get => _threeStarCount;
+            private set => Set(ref _threeStarCount, value);
+        }
+
+        private int _twoStarCount;
+        public int TwoStarCount
+        {
+            get => _twoStarCount;
+            private set => Set(ref _twoStarCount, value);
+        }
+
+        private int _oneStarCount;
+        public int OneStarCount
+        {
+            get => _oneStarCount;
+            private set => Set(ref _oneStarCount, value);
+        }
+
+        public double FiveStarRatio => TotalReviews > 0 ? (double)FiveStarCount / TotalReviews * 100 : 0;
+        public double FourStarRatio => TotalReviews > 0 ? (double)FourStarCount / TotalReviews * 100 : 0;
+        public double ThreeStarRatio => TotalReviews > 0 ? (double)ThreeStarCount / TotalReviews * 100 : 0;
+        public double TwoStarRatio => TotalReviews > 0 ? (double)TwoStarCount / TotalReviews * 100 : 0;
+        public double OneStarRatio => TotalReviews > 0 ? (double)OneStarCount / TotalReviews * 100 : 0;
+
         public HotelAdminViewModel(
             IReviewRepository reviewRepository,
             IUserRepository userRepository,
@@ -138,6 +193,26 @@ namespace Hotel_Booking_System.ViewModels
             {
                 Reviews.Add(review);
             }
+
+            CalculateReviewStatistics();
+        }
+
+        private void CalculateReviewStatistics()
+        {
+            TotalReviews = Reviews.Count;
+            AverageRating = TotalReviews > 0 ? Reviews.Average(r => r.Rating) : 0;
+
+            FiveStarCount = Reviews.Count(r => r.Rating == 5);
+            FourStarCount = Reviews.Count(r => r.Rating == 4);
+            ThreeStarCount = Reviews.Count(r => r.Rating == 3);
+            TwoStarCount = Reviews.Count(r => r.Rating == 2);
+            OneStarCount = Reviews.Count(r => r.Rating == 1);
+
+            OnPropertyChanged(nameof(FiveStarRatio));
+            OnPropertyChanged(nameof(FourStarRatio));
+            OnPropertyChanged(nameof(ThreeStarRatio));
+            OnPropertyChanged(nameof(TwoStarRatio));
+            OnPropertyChanged(nameof(OneStarRatio));
         }
 
         [RelayCommand]

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -298,37 +298,37 @@
                                 </Grid.ColumnDefinitions>
 
                                 <StackPanel Grid.Column="0" HorizontalAlignment="Center">
-                                    <TextBlock Text="0" FontSize="48" FontWeight="Bold" Foreground="#FF4CAF50" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding AverageRating, StringFormat={}{0:F1}}" FontSize="48" FontWeight="Bold" Foreground="#FF4CAF50" HorizontalAlignment="Center"/>
                                     <TextBlock Text="⭐⭐⭐⭐⭐" FontSize="20" HorizontalAlignment="Center" Margin="0,5"/>
                                     <TextBlock Text="Overall Rating" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Based on " FontSize="12" Foreground="#FF666666" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding TotalReviews, StringFormat=Based on {0} reviews}" FontSize="12" Foreground="#FF666666" HorizontalAlignment="Center"/>
                                 </StackPanel>
 
                                 <StackPanel Grid.Column="1">
                                     <StackPanel Orientation="Horizontal" Margin="0,5">
                                         <TextBlock Text="5⭐" Width="30"/>
-                                        <ProgressBar Value="0" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
-                                        <TextBlock Text="0" Width="30" TextAlignment="Right"/>
+                                        <ProgressBar Value="{Binding FiveStarRatio, Mode=OneWay}" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
+                                        <TextBlock Text="{Binding FiveStarCount}" Width="30" TextAlignment="Right"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="0,5">
                                         <TextBlock Text="4⭐" Width="30"/>
-                                        <ProgressBar Value="0" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
-                                        <TextBlock Text="0" Width="30" TextAlignment="Right"/>
+                                        <ProgressBar Value="{Binding FourStarRatio, Mode=OneWay}" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
+                                        <TextBlock Text="{Binding FourStarCount}" Width="30" TextAlignment="Right"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="0,5">
                                         <TextBlock Text="3⭐" Width="30"/>
-                                        <ProgressBar Value="0" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
-                                        <TextBlock Text="0" Width="30" TextAlignment="Right"/>
+                                        <ProgressBar Value="{Binding ThreeStarRatio, Mode=OneWay}" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
+                                        <TextBlock Text="{Binding ThreeStarCount}" Width="30" TextAlignment="Right"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="0,5">
                                         <TextBlock Text="2⭐" Width="30"/>
-                                        <ProgressBar Value="0" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
-                                        <TextBlock Text="0" Width="30" TextAlignment="Right"/>
+                                        <ProgressBar Value="{Binding TwoStarRatio, Mode=OneWay}" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
+                                        <TextBlock Text="{Binding TwoStarCount}" Width="30" TextAlignment="Right"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="0,5">
                                         <TextBlock Text="1⭐" Width="30"/>
-                                        <ProgressBar Value="0" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
-                                        <TextBlock Text="0" Width="30" TextAlignment="Right"/>
+                                        <ProgressBar Value="{Binding OneStarRatio, Mode=OneWay}" Width="100" Height="10" VerticalAlignment="Center" Margin="10,0"/>
+                                        <TextBlock Text="{Binding OneStarCount}" Width="30" TextAlignment="Right"/>
                                     </StackPanel>
                                 </StackPanel>
 


### PR DESCRIPTION
## Summary
- add review statistic properties to HotelAdminViewModel and interface
- bind rating bars and counters in HotelAdminWindow to computed percentages
- set review progress bars to one-way mode to avoid binding to read-only properties

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c808d247488333bee1b707c38ff69c