### PR TITLE
Fix star rating binding for current hotel

### DIFF
--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -119,12 +119,14 @@
 
                                     <StackPanel Grid.Row="0" Grid.Column="1" Margin="15,0,0,15">
                                         <TextBlock Text="Star Rating" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                        <ComboBox Style="{StaticResource ModernComboBox}"  FontSize="14">
-                                            <ComboBoxItem Content="⭐⭐⭐⭐⭐ 5 Stars" IsSelected="True"/>
-                                            <ComboBoxItem Content="⭐⭐⭐⭐ 4 Stars"/>
-                                            <ComboBoxItem Content="⭐⭐⭐ 3 Stars"/>
-                                            <ComboBoxItem Content="⭐⭐ 2 Stars"/>
-                                            <ComboBoxItem Content="⭐ 1 Stars"/>
+                                        <ComboBox Style="{StaticResource ModernComboBox}" FontSize="14"
+                                                  SelectedValuePath="Tag"
+                                                  SelectedValue="{Binding CurrentHotel.Rating, Mode=TwoWay}">
+                                            <ComboBoxItem Tag="5" Content="⭐⭐⭐⭐⭐ 5 Stars"/>
+                                            <ComboBoxItem Tag="4" Content="⭐⭐⭐⭐ 4 Stars"/>
+                                            <ComboBoxItem Tag="3" Content="⭐⭐⭐ 3 Stars"/>
+                                            <ComboBoxItem Tag="2" Content="⭐⭐ 2 Stars"/>
+                                            <ComboBoxItem Tag="1" Content="⭐ 1 Stars"/>
                                         </ComboBox>
                                     </StackPanel>
 


### PR DESCRIPTION
## Summary
- bind the hotel management star rating combo box to the current hotel's rating
- map combo box options to numeric rating values using SelectedValuePath

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5c73e4e883338231463c11558fcb