### PR TITLE
Bind hotel amenities to limited set

### DIFF
--- a/Interfaces/IHotelAdminViewModel.cs
+++ b/Interfaces/IHotelAdminViewModel.cs
@@ -15,6 +15,12 @@ namespace Hotel_Booking_System.Interfaces
         ObservableCollection<Review> Reviews { get; }
         User CurrentUser { get; set; }
 
+        bool HasFreeWifi { get; set; }
+        bool HasSwimmingPool { get; set; }
+        bool HasFreeParking { get; set; }
+        bool HasRestaurant { get; set; }
+        bool HasGym { get; set; }
+
         int TotalReviews { get; }
         double AverageRating { get; }
 

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -145,14 +145,16 @@
                                     <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Margin="0,0,0,15">
                                         <TextBlock Text="Amenities" FontWeight="SemiBold" Margin="0,0,0,10"/>
                                         <WrapPanel>
-                                            <CheckBox Content="🌐 Free WiFi" IsChecked="True" Margin="0,0,15,5"/>
-                                            <CheckBox Content="🏊 Swimming Pool" IsChecked="True" Margin="0,0,15,5"/>
-                                            <CheckBox Content="🚗 Free Parking" IsChecked="True" Margin="0,0,15,5"/>
-                                            <CheckBox Content="💪 Fitness Center" IsChecked="True" Margin="0,0,15,5"/>
-                                            <CheckBox Content="🍽️ Restaurant" IsChecked="True" Margin="0,0,15,5"/>
-                                            <CheckBox Content="🛎️ Room Service" IsChecked="True" Margin="0,0,15,5"/>
-                                            <CheckBox Content="🅿️ Valet Parking" Margin="0,0,15,5"/>
-                                            <CheckBox Content="🏪 Business Center" Margin="0,0,15,5"/>
+                                            <CheckBox Content="🌐 Free WiFi" Margin="0,0,15,5"
+                                                      IsChecked="{Binding HasFreeWifi, Mode=TwoWay}"/>
+                                            <CheckBox Content="🏊 Swimming Pool" Margin="0,0,15,5"
+                                                      IsChecked="{Binding HasSwimmingPool, Mode=TwoWay}"/>
+                                            <CheckBox Content="🚗 Free Parking" Margin="0,0,15,5"
+                                                      IsChecked="{Binding HasFreeParking, Mode=TwoWay}"/>
+                                            <CheckBox Content="🍽️ Restaurant" Margin="0,0,15,5"
+                                                      IsChecked="{Binding HasRestaurant, Mode=TwoWay}"/>
+                                            <CheckBox Content="🏋️ Gym" Margin="0,0,15,5"
+                                                      IsChecked="{Binding HasGym, Mode=TwoWay}"/>
                                         </WrapPanel>
                                     </StackPanel>
                                                                     <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Margin="0,0,0,15">


### PR DESCRIPTION
## Summary
- expose amenity selection flags on the hotel admin view model and sync them with the current hotel's amenities
- limit the hotel manager amenity checklist to the five options available in the user hotel filter and bind them to the new properties

## Testing
- dotnet build Hotel_Booking_System.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5df85e8c83338adfa8f39592525a