### PR TITLE
Ensure review replies update UI and user reviews scroll

### DIFF
--- a/DomainModels/Review.cs
+++ b/DomainModels/Review.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
@@ -8,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Hotel_Booking_System.DomainModels
 {
-    public class Review
+    public class Review : INotifyPropertyChanged
     {
         [Key]
         public string ReviewID { get; set; }
@@ -20,10 +21,78 @@ namespace Hotel_Booking_System.DomainModels
         public string Comment { get; set; }
         public DateTime CreatedAt { get; set; }
 
-        [NotMapped]
-        public string ReviewerName { get; set; } = string.Empty;
+        private string? _adminReply;
+        public string? AdminReply
+        {
+            get => _adminReply;
+            set
+            {
+                if (_adminReply == value)
+                {
+                    return;
+                }
+
+                _adminReply = value;
+                OnPropertyChanged(nameof(AdminReply));
+            }
+        }
 
         [NotMapped]
-        public string ReviewerAvatarUrl { get; set; } = string.Empty;
+        private string _reviewerName = string.Empty;
+        public string ReviewerName
+        {
+            get => _reviewerName;
+            set
+            {
+                if (_reviewerName == value)
+                {
+                    return;
+                }
+
+                _reviewerName = value;
+                OnPropertyChanged(nameof(ReviewerName));
+            }
+        }
+
+        [NotMapped]
+        private string _reviewerAvatarUrl = string.Empty;
+        public string ReviewerAvatarUrl
+        {
+            get => _reviewerAvatarUrl;
+            set
+            {
+                if (_reviewerAvatarUrl == value)
+                {
+                    return;
+                }
+
+                _reviewerAvatarUrl = value;
+                OnPropertyChanged(nameof(ReviewerAvatarUrl));
+            }
+        }
+
+        [NotMapped]
+        private string _adminReplyDraft = string.Empty;
+        public string AdminReplyDraft
+        {
+            get => _adminReplyDraft;
+            set
+            {
+                if (_adminReplyDraft == value)
+                {
+                    return;
+                }
+
+                _adminReplyDraft = value;
+                OnPropertyChanged(nameof(AdminReplyDraft));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 }

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -943,7 +943,10 @@ namespace Hotel_Booking_System.ViewModels
         {
             Reviews.Clear();
             var reviewList = _reviewRepository.GetAllAsync().Result;
-            var hotelReviews = reviewList.Where(r => r.HotelID == hotelId).ToList();
+            var hotelReviews = reviewList
+                .Where(r => r.HotelID == hotelId)
+                .OrderByDescending(r => r.CreatedAt)
+                .ToList();
             foreach (var review in hotelReviews)
             {
                 var user = _userRepository.GetByIdAsync(review.UserID).Result;
@@ -952,6 +955,7 @@ namespace Hotel_Booking_System.ViewModels
                     review.ReviewerName = user.FullName;
                     review.ReviewerAvatarUrl = user.AvatarUrl;
                 }
+                review.AdminReplyDraft = string.Empty;
                 Reviews.Add(review);
             }
         }

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -349,14 +349,133 @@
                         <Border Style="{StaticResource CardStyle}">
                             <StackPanel Margin="25">
                                 <TextBlock Text="Recent Reviews" FontSize="16" FontWeight="Bold" Margin="0,0,0,15"/>
-                                <ListView x:Name="lvAdminReviews" ItemsSource="{Binding Reviews}" BorderThickness="0" Background="Transparent">
+                                <ListView x:Name="lvAdminReviews"
+                                          ItemsSource="{Binding Reviews}"
+                                          BorderThickness="0"
+                                          Background="Transparent"
+                                          ScrollViewer.VerticalScrollBarVisibility="Auto">
                                     <ListView.ItemTemplate>
                                         <DataTemplate>
-                                            <Border BorderBrush="#FFE0E0E0" BorderThickness="0,0,0,1" Padding="0,0,0,15" Margin="0,0,0,15">
-                                                <StackPanel>
-                                                    <TextBlock Text="{Binding Rating, StringFormat='Rating: {0}'}" FontWeight="Bold"/>
-                                                    <TextBlock Text="{Binding Comment}" TextWrapping="Wrap"/>
-                                                </StackPanel>
+                                            <Border BorderBrush="#FFE0E0E0"
+                                                    BorderThickness="0,0,0,1"
+                                                    Padding="0,0,0,20"
+                                                    Margin="0,0,0,15">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <Border Width="48"
+                                                            Height="48"
+                                                            CornerRadius="24"
+                                                            Background="#FFE0E0E0"
+                                                            ClipToBounds="True"
+                                                            Margin="0,4,20,0">
+                                                        <Image Source="{Binding ReviewerAvatarUrl}"
+                                                               Stretch="UniformToFill"/>
+                                                    </Border>
+
+                                                    <StackPanel Grid.Column="1">
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="{Binding ReviewerName}"
+                                                                       FontWeight="Bold"
+                                                                       FontSize="14"/>
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{Binding CreatedAt, StringFormat='{}{0:MMM dd, yyyy}'}"
+                                                                       FontSize="12"
+                                                                       Foreground="#FF757575"
+                                                                       HorizontalAlignment="Right"/>
+                                                        </Grid>
+
+                                                        <TextBlock Text="{Binding Rating, StringFormat='{}{0}/5 ⭐'}"
+                                                                   Foreground="#FFFF9800"
+                                                                   FontWeight="SemiBold"
+                                                                   Margin="0,4,0,0"/>
+
+                                                        <TextBlock Text="{Binding Comment}"
+                                                                   TextWrapping="Wrap"
+                                                                   Margin="0,6,0,0"/>
+
+                                                        <Border Background="#FFF1F8E9"
+                                                                BorderBrush="#FFE0E0E0"
+                                                                BorderThickness="1"
+                                                                CornerRadius="6"
+                                                                Padding="10"
+                                                                Margin="0,12,0,0">
+                                                            <Border.Style>
+                                                                <Style TargetType="Border">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="{x:Null}">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Border.Style>
+                                                            <StackPanel>
+                                                                <TextBlock Text="Your reply"
+                                                                           FontWeight="Bold"
+                                                                           FontSize="12"
+                                                                           Foreground="#FF33691E"/>
+                                                                <TextBlock Text="{Binding AdminReply}"
+                                                                           TextWrapping="Wrap"
+                                                                           Margin="0,4,0,0"/>
+                                                            </StackPanel>
+                                                        </Border>
+
+                                                        <StackPanel Margin="0,12,0,0">
+                                                            <StackPanel.Style>
+                                                                <Style TargetType="StackPanel">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="{x:Null}">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </StackPanel.Style>
+                                                            <TextBlock Text="Reply to this review"
+                                                                       FontWeight="SemiBold"
+                                                                       FontSize="12"
+                                                                       Margin="0,0,0,6"/>
+                                                            <TextBox Text="{Binding AdminReplyDraft, UpdateSourceTrigger=PropertyChanged}"
+                                                                     AcceptsReturn="True"
+                                                                     Height="60"
+                                                                     TextWrapping="Wrap"
+                                                                     Style="{StaticResource ModernTextBox}"/>
+                                                            <Button Content="Send reply"
+                                                                    Width="120"
+                                                                    Margin="0,10,0,0"
+                                                                    Command="{Binding DataContext.ReplyToReviewCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                    CommandParameter="{Binding}">
+                                                                <Button.Style>
+                                                                    <Style TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+                                                                        <Setter Property="IsEnabled" Value="True"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding AdminReplyDraft}" Value="">
+                                                                                <Setter Property="IsEnabled" Value="False"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding AdminReplyDraft}" Value="{x:Null}">
+                                                                                <Setter Property="IsEnabled" Value="False"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </Button.Style>
+                                                            </Button>
+                                                        </StackPanel>
+                                                    </StackPanel>
+                                                </Grid>
                                             </Border>
                                         </DataTemplate>
                                     </ListView.ItemTemplate>

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -337,21 +337,91 @@
                                         </ListView.ItemTemplate>
                                     </ListView>
 
-                                    <ListView Grid.Row="2" Grid.Column="1" Margin="4,0,20,20" ItemsSource="{Binding Reviews}" Background="Transparent" BorderThickness="0" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                        <ListView.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border BorderBrush="#FFE0E0E0" BorderThickness="0,0,0,1" Padding="0,10">
-                                                    <StackPanel Orientation="Horizontal">
-                                                        <Image Source="{Binding ReviewerAvatarUrl}" Width="40" Height="40" Margin="0,0,10,0"/>
-                                                        <StackPanel>
-                                                            <TextBlock Text="{Binding ReviewerName}" FontWeight="Bold"/>
-                                                            <TextBlock Text="{Binding Rating, StringFormat='Rating: {0}'}"/>
-                                                            <TextBlock Text="{Binding Comment}" TextWrapping="Wrap"/>
-                                                        </StackPanel>
+                                    <ListView Grid.Row="2" Grid.Column="1"
+                                              Margin="4,0,20,20"
+                                              ItemsSource="{Binding Reviews}"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              MaxHeight="420"
+                                              ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border BorderBrush="#FFE0E0E0"
+                                                    BorderThickness="0,0,0,1"
+                                                    Padding="0,12"
+                                                    Margin="0,0,0,8">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <Border Width="44"
+                                                            Height="44"
+                                                            CornerRadius="22"
+                                                            Background="#FFE0E0E0"
+                                                            ClipToBounds="True"
+                                                            Margin="0,0,12,0">
+                                                        <Image Source="{Binding ReviewerAvatarUrl}"
+                                                               Stretch="UniformToFill"/>
+                                                    </Border>
+
+                                                    <StackPanel Grid.Column="1">
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="{Binding ReviewerName}"
+                                                                       FontWeight="Bold"
+                                                                       FontSize="14"/>
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{Binding CreatedAt, StringFormat='{}{0:MMM dd, yyyy}'}"
+                                                                       FontSize="12"
+                                                                       Foreground="#FF757575"
+                                                                       HorizontalAlignment="Right"/>
+                                                        </Grid>
+                                                        <TextBlock Text="{Binding Rating, StringFormat='{}{0}/5 ⭐'}"
+                                                                   Foreground="#FFFF9800"
+                                                                   FontWeight="SemiBold"
+                                                                   Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding Comment}"
+                                                                   TextWrapping="Wrap"
+                                                                   Margin="0,6,0,0"/>
+                                                        <Border Background="#FFF3E5F5"
+                                                                BorderBrush="#FFE0E0E0"
+                                                                BorderThickness="1"
+                                                                CornerRadius="6"
+                                                                Padding="10"
+                                                                Margin="0,10,0,0">
+                                                            <Border.Style>
+                                                                <Style TargetType="Border">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="{x:Null}">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Border.Style>
+                                                            <StackPanel>
+                                                                <TextBlock Text="Hotel response"
+                                                                           FontWeight="Bold"
+                                                                           FontSize="12"
+                                                                           Foreground="#FF6A1B9A"/>
+                                                                <TextBlock Text="{Binding AdminReply}"
+                                                                           TextWrapping="Wrap"
+                                                                           Margin="0,4,0,0"/>
+                                                            </StackPanel>
+                                                        </Border>
                                                     </StackPanel>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ListView.ItemTemplate>
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
                                     </ListView>
                                 </Grid>
                             </Border>


### PR DESCRIPTION
## Summary
- add property change notifications to the Review model so UI elements react once an admin reply is saved
- limit the guest review list height so it scrolls instead of stretching the layout

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb66174a4083338ff7149beab8698f