### PR TITLE
Replace admin revenue charts with interactive line analytics

### DIFF
--- a/Hotel_Booking_System.csproj
+++ b/Hotel_Booking_System.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Mscc.GenerativeAI" Version="2.8.9" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -15,6 +15,10 @@ using Hotel_Booking_System.Views;
 using Hotel_Manager.FrameWorks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Win32;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
 
 namespace Hotel_Booking_System.ViewModels
 {
@@ -69,6 +73,45 @@ namespace Hotel_Booking_System.ViewModels
         public ObservableCollection<Room> Rooms { get; } = new();
         public ObservableCollection<Booking> Bookings { get; } = new();
         public ObservableCollection<string> BookingStatusFilters { get; } = new();
+
+        private readonly Dictionary<RevenueRange, List<RevenueDataPoint>> _revenueData = new();
+        private List<Payment> _currentHotelPayments = new();
+
+        public ObservableCollection<RevenueFilterOption> RevenueFilterOptions { get; } = new();
+
+        private RevenueFilterOption? _selectedRevenueFilter;
+        public RevenueFilterOption? SelectedRevenueFilter
+        {
+            get => _selectedRevenueFilter;
+            set
+            {
+                Set(ref _selectedRevenueFilter, value);
+                UpdateRevenueChart();
+            }
+        }
+
+        public ObservableCollection<ISeries> RevenueSeries { get; } = new();
+
+        private Axis[] _revenueXAxes = Array.Empty<Axis>();
+        public Axis[] RevenueXAxes
+        {
+            get => _revenueXAxes;
+            private set => Set(ref _revenueXAxes, value);
+        }
+
+        private Axis[] _revenueYAxes = Array.Empty<Axis>();
+        public Axis[] RevenueYAxes
+        {
+            get => _revenueYAxes;
+            private set => Set(ref _revenueYAxes, value);
+        }
+
+        private string _revenueSummary = "Chưa có dữ liệu doanh thu.";
+        public string RevenueSummary
+        {
+            get => _revenueSummary;
+            private set => Set(ref _revenueSummary, value);
+        }
 
         private string _selectedBookingStatusFilter = "All";
         public string SelectedBookingStatusFilter
@@ -335,6 +378,34 @@ namespace Hotel_Booking_System.ViewModels
             _navigationService = navigationService;
             _authenticationService = authenticationService;
 
+            RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Theo ngày", Range = RevenueRange.Daily });
+            RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Theo tháng", Range = RevenueRange.Monthly });
+            RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Theo năm", Range = RevenueRange.Yearly });
+            RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Tổng", Range = RevenueRange.Cumulative });
+
+            RevenueXAxes = new[]
+            {
+                new Axis
+                {
+                    Labels = Array.Empty<string>(),
+                    TextSize = 14
+                }
+            };
+
+            RevenueYAxes = new[]
+            {
+                new Axis
+                {
+                    Labeler = value => value.ToString("N0") + " ₫",
+                    MinLimit = 0,
+                    TextSize = 14,
+                    SeparatorsPaint = new SolidColorPaint(SKColors.LightGray)
+                    {
+                        StrokeThickness = 1
+                    }
+                }
+            };
+
             WeakReferenceMessenger.Default.Register<HotelAdminViewModel, MessageService>(this, (recipient, message) =>
             {
                 recipient._userEmail = message.Value;
@@ -402,6 +473,7 @@ namespace Hotel_Booking_System.ViewModels
 
             UpdateBookingStatusFilters();
             ApplyBookingFilter();
+            UpdateRevenueAnalytics(bookings);
         }
 
         private async void LoadReviews()
@@ -603,6 +675,270 @@ namespace Hotel_Booking_System.ViewModels
             }
 
             return "Bronze";
+        }
+
+        private void UpdateRevenueAnalytics(List<Booking> bookings)
+        {
+            _currentHotelPayments = new List<Payment>();
+            _revenueData.Clear();
+
+            if (bookings != null && bookings.Count > 0)
+            {
+                var bookingIds = bookings
+                    .Select(b => b.BookingID)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .ToHashSet();
+
+                if (bookingIds.Count > 0)
+                {
+                    _currentHotelPayments = _paymentRepository.GetAllAsync().Result
+                        .Where(p => !string.IsNullOrWhiteSpace(p.BookingID) && bookingIds.Contains(p.BookingID))
+                        .ToList();
+                }
+            }
+
+            var today = DateTime.Today;
+
+            _revenueData[RevenueRange.Daily] = BuildDailyRevenue(_currentHotelPayments, today);
+            _revenueData[RevenueRange.Monthly] = BuildMonthlyRevenue(_currentHotelPayments, today);
+            _revenueData[RevenueRange.Yearly] = BuildYearlyRevenue(_currentHotelPayments, today);
+            _revenueData[RevenueRange.Cumulative] = BuildCumulativeRevenue(_currentHotelPayments, today);
+
+            if (SelectedRevenueFilter == null)
+            {
+                SelectedRevenueFilter = RevenueFilterOptions.FirstOrDefault();
+            }
+            else
+            {
+                UpdateRevenueChart();
+            }
+        }
+
+        private List<RevenueDataPoint> BuildDailyRevenue(List<Payment> payments, DateTime referenceDate)
+        {
+            payments ??= new List<Payment>();
+            var result = new List<RevenueDataPoint>();
+            var startDate = referenceDate.AddDays(-13);
+
+            for (int i = 0; i < 14; i++)
+            {
+                var currentDate = startDate.AddDays(i).Date;
+                var amount = payments
+                    .Where(p => p.PaymentDate.Date == currentDate)
+                    .Sum(p => p.TotalPayment);
+
+                result.Add(new RevenueDataPoint
+                {
+                    Label = currentDate.ToString("dd/MM"),
+                    Amount = amount,
+                    Timestamp = currentDate
+                });
+            }
+
+            return result;
+        }
+
+        private List<RevenueDataPoint> BuildMonthlyRevenue(List<Payment> payments, DateTime referenceDate)
+        {
+            payments ??= new List<Payment>();
+            var result = new List<RevenueDataPoint>();
+            var startMonth = new DateTime(referenceDate.Year, referenceDate.Month, 1).AddMonths(-11);
+
+            for (int i = 0; i < 12; i++)
+            {
+                var currentMonthStart = startMonth.AddMonths(i);
+                var nextMonthStart = currentMonthStart.AddMonths(1);
+                var amount = payments
+                    .Where(p => p.PaymentDate >= currentMonthStart && p.PaymentDate < nextMonthStart)
+                    .Sum(p => p.TotalPayment);
+
+                result.Add(new RevenueDataPoint
+                {
+                    Label = currentMonthStart.ToString("MM/yyyy"),
+                    Amount = amount,
+                    Timestamp = currentMonthStart
+                });
+            }
+
+            return result;
+        }
+
+        private List<RevenueDataPoint> BuildYearlyRevenue(List<Payment> payments, DateTime referenceDate)
+        {
+            payments ??= new List<Payment>();
+            var result = new List<RevenueDataPoint>();
+            var startYear = new DateTime(referenceDate.Year - 4, 1, 1);
+
+            for (int i = 0; i < 5; i++)
+            {
+                var currentYearStart = startYear.AddYears(i);
+                var nextYearStart = currentYearStart.AddYears(1);
+                var amount = payments
+                    .Where(p => p.PaymentDate >= currentYearStart && p.PaymentDate < nextYearStart)
+                    .Sum(p => p.TotalPayment);
+
+                result.Add(new RevenueDataPoint
+                {
+                    Label = currentYearStart.Year.ToString(),
+                    Amount = amount,
+                    Timestamp = currentYearStart
+                });
+            }
+
+            return result;
+        }
+
+        private List<RevenueDataPoint> BuildCumulativeRevenue(List<Payment> payments, DateTime referenceDate)
+        {
+            payments ??= new List<Payment>();
+            var result = new List<RevenueDataPoint>();
+
+            var grouped = payments
+                .GroupBy(p => p.PaymentDate.Date)
+                .OrderBy(g => g.Key);
+
+            double runningTotal = 0;
+            foreach (var group in grouped)
+            {
+                runningTotal += group.Sum(p => p.TotalPayment);
+                result.Add(new RevenueDataPoint
+                {
+                    Label = group.Key.ToString("dd/MM/yyyy"),
+                    Amount = runningTotal,
+                    Timestamp = group.Key
+                });
+            }
+
+            if (result.Count == 0)
+            {
+                result.Add(new RevenueDataPoint
+                {
+                    Label = referenceDate.ToString("dd/MM/yyyy"),
+                    Amount = 0,
+                    Timestamp = referenceDate
+                });
+            }
+
+            return result;
+        }
+
+        private void UpdateRevenueChart()
+        {
+            if (SelectedRevenueFilter == null)
+            {
+                RevenueSeries.Clear();
+                RevenueXAxes = new[]
+                {
+                    new Axis
+                    {
+                        Labels = Array.Empty<string>(),
+                        TextSize = 14
+                    }
+                };
+                RevenueSummary = "Chưa có dữ liệu doanh thu.";
+                return;
+            }
+
+            if (!_revenueData.TryGetValue(SelectedRevenueFilter.Range, out var data))
+            {
+                data = new List<RevenueDataPoint>();
+            }
+
+            if (data.Count == 0)
+            {
+                RevenueSeries.Clear();
+                RevenueSeries.Add(new LineSeries<double>
+                {
+                    Values = new double[] { 0 },
+                    GeometrySize = 0,
+                    Fill = null,
+                    Stroke = new SolidColorPaint(SKColors.LightGray)
+                    {
+                        StrokeThickness = 2
+                    }
+                });
+
+                RevenueXAxes = new[]
+                {
+                    new Axis
+                    {
+                        Labels = new[] { "Không có dữ liệu" },
+                        TextSize = 14
+                    }
+                };
+
+                RevenueSummary = "Chưa có dữ liệu doanh thu.";
+                return;
+            }
+
+            var labels = data.Select(d => d.Label).ToArray();
+            var values = data.Select(d => d.Amount).ToArray();
+
+            RevenueSeries.Clear();
+            RevenueSeries.Add(new LineSeries<double>
+            {
+                Values = values,
+                Fill = null,
+                LineSmoothness = 0.4,
+                GeometrySize = 10,
+                Stroke = new SolidColorPaint(SKColors.DeepSkyBlue)
+                {
+                    StrokeThickness = 3
+                },
+                GeometryStroke = new SolidColorPaint(SKColors.DeepSkyBlue),
+                GeometryFill = new SolidColorPaint(SKColors.White),
+                TooltipLabelFormatter = chartPoint =>
+                {
+                    var index = (int)Math.Round(chartPoint.SecondaryValue);
+                    if (index >= 0 && index < labels.Length)
+                    {
+                        return $"{labels[index]}: {chartPoint.PrimaryValue:N0} ₫";
+                    }
+
+                    return $"{chartPoint.PrimaryValue:N0} ₫";
+                }
+            });
+
+            RevenueXAxes = new[]
+            {
+                new Axis
+                {
+                    Labels = labels,
+                    LabelsRotation = -45,
+                    TextSize = 14
+                }
+            };
+
+            var firstDate = data.First().Timestamp;
+            var lastDate = data.Last().Timestamp;
+            double total = SelectedRevenueFilter.Range == RevenueRange.Cumulative
+                ? data.Last().Amount
+                : data.Sum(d => d.Amount);
+
+            string modeDescription = SelectedRevenueFilter.Range switch
+            {
+                RevenueRange.Daily => "theo ngày",
+                RevenueRange.Monthly => "theo tháng",
+                RevenueRange.Yearly => "theo năm",
+                RevenueRange.Cumulative => "tích lũy",
+                _ => string.Empty
+            };
+
+            string rangeDescription = SelectedRevenueFilter.Range switch
+            {
+                RevenueRange.Daily => $"({firstDate:dd/MM} - {lastDate:dd/MM})",
+                RevenueRange.Monthly => $"({firstDate:MM/yyyy} - {lastDate:MM/yyyy})",
+                RevenueRange.Yearly => $"({firstDate:yyyy} - {lastDate:yyyy})",
+                RevenueRange.Cumulative => $"(đến {lastDate:dd/MM/yyyy})",
+                _ => string.Empty
+            };
+
+            if (!string.IsNullOrWhiteSpace(rangeDescription))
+            {
+                rangeDescription = " " + rangeDescription;
+            }
+
+            RevenueSummary = $"Tổng doanh thu {modeDescription}{rangeDescription}: {total:N0} ₫";
         }
 
         private void SyncAmenitiesFromHotel()
@@ -943,6 +1279,27 @@ namespace Hotel_Booking_System.ViewModels
                 LoadBookings();
             }
         }
+    }
+
+    public class RevenueDataPoint
+    {
+        public string Label { get; set; } = string.Empty;
+        public double Amount { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
+    public class RevenueFilterOption
+    {
+        public string DisplayName { get; set; } = string.Empty;
+        public RevenueRange Range { get; set; }
+    }
+
+    public enum RevenueRange
+    {
+        Daily,
+        Monthly,
+        Yearly,
+        Cumulative
     }
 }
 

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Hotel_Booking_System.Views"
+        xmlns:lvc="http://schemas.livecharts.com/wpf"
         mc:Ignorable="d"
             Title="Multi-Hotel Booking System" Height="900" Width="1400"
         WindowState="Maximized"
@@ -282,7 +283,43 @@
                 </ScrollViewer>
             </TabItem>
 
-            
+
+            <TabItem Style="{StaticResource TabItemStyle}" x:Name="RevenueTab" Header="💰 Doanh thu" Visibility="Visible">
+                <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Text="Tổng quan doanh thu" Style="{StaticResource HeaderTextStyle}"/>
+                        <TextBlock Text="Chọn khoảng thời gian để theo dõi đường doanh thu và xu hướng kinh doanh của khách sạn." Margin="0,8,0,20" Foreground="#FF666666"/>
+
+                        <Border Style="{StaticResource CardStyle}">
+                            <StackPanel Margin="25">
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                    <TextBlock Text="Hiển thị:" VerticalAlignment="Center" Foreground="#FF424242" FontWeight="SemiBold"/>
+                                    <ComboBox Width="220"
+                                              Margin="12,0,0,0"
+                                              Style="{StaticResource ModernComboBox}"
+                                              ItemsSource="{Binding RevenueFilterOptions}"
+                                              SelectedItem="{Binding SelectedRevenueFilter}"
+                                              DisplayMemberPath="DisplayName"/>
+                                </StackPanel>
+
+                                <lvc:CartesianChart Margin="0,20,0,16"
+                                                    Series="{Binding RevenueSeries}"
+                                                    XAxes="{Binding RevenueXAxes}"
+                                                    YAxes="{Binding RevenueYAxes}"
+                                                    ZoomMode="X"
+                                                    AnimationsSpeed="0:0:0.6"
+                                                    LegendPosition="Hidden"/>
+
+                                <TextBlock Text="{Binding RevenueSummary}"
+                                           FontSize="16"
+                                           FontWeight="SemiBold"
+                                           Foreground="#FF424242"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
             <TabItem Style="{StaticResource TabItemStyle}" x:Name="ReviewsTab" Header="⭐ Reviews" Visibility="Visible">
                 <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
                     <StackPanel>


### PR DESCRIPTION
## Summary
- replace the hotel admin revenue tab with a LiveCharts-based line chart and a combo box for choosing day, month, year, or cumulative revenue views
- extend the hotel admin view model to prepare time-range revenue series, summary text, and axis metadata for the new chart bindings
- add the LiveChartsCore WPF package and remove the obsolete bar-height converter used by the prior revenue tab

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce07a9cc24833388df10d66325e4d3