### PR TITLE
Fix nullability issues and update revenue analytics

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -27,14 +27,12 @@ namespace Hotel_Booking_System
         {
             base.OnStartup(e);
             Env.Load();
-            using (var scope = Provider?.CreateScope())
-            {
-                var context = scope?.ServiceProvider.GetRequiredService<AppDbContext>();
-                context?.SeedData();
-            }
+            using var scope = Provider.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            context.SeedData();
         }
         private static IServiceProvider? provider;
-        public static IServiceProvider? Provider { get => provider ??= ConfigDI(); }
+        public static IServiceProvider Provider => provider ??= ConfigDI();
         private static IServiceProvider ConfigDI()
         {
             var geminiOptions = new GeminiOptions

--- a/DomainModels/AIChat.cs
+++ b/DomainModels/AIChat.cs
@@ -12,11 +12,11 @@ namespace Hotel_Booking_System.DomainModels
     public class AIChat : Bindable
     {
         [Key]
-        public string ChatID {  get; set; }
-        public string UserID { get; set; }
-        public string Message { get; set; }
+        public string ChatID {  get; set; } = string.Empty;
+        public string UserID { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
 
-        private string _response;
+        private string _response = string.Empty;
         public string Response
         {
             get => _response;

--- a/DomainModels/Amenity.cs
+++ b/DomainModels/Amenity.cs
@@ -10,8 +10,8 @@ namespace Hotel_Booking_System.DomainModels
     public class Amenity
     {
         [Key]
-        public string AmenityID { get; set; }
-        public string AmenityName { get; set; } = "";
+        public string AmenityID { get; set; } = string.Empty;
+        public string AmenityName { get; set; } = string.Empty;
 
         public ICollection<Hotel> Hotels { get; set; } = new List<Hotel>();
     }

--- a/DomainModels/Booking.cs
+++ b/DomainModels/Booking.cs
@@ -11,15 +11,15 @@ namespace Hotel_Booking_System.DomainModels
     public class Booking
     {
         [Key]
-        public string BookingID { get; set; }
-        public string HotelID { get; set; } = "";
-        public string RoomID { get; set; } = "";
-        public string UserID { get; set; } = "";
-        public string GuestName { get; set; } = "";
+        public string BookingID { get; set; } = string.Empty;
+        public string HotelID { get; set; } = string.Empty;
+        public string RoomID { get; set; } = string.Empty;
+        public string UserID { get; set; } = string.Empty;
+        public string GuestName { get; set; } = string.Empty;
         public int NumberOfGuests { get; set; }
         public DateTime CheckInDate { get; set; }
         public DateTime CheckOutDate { get; set; }
-        public string Status { get; set; } = "";
+        public string Status { get; set; } = string.Empty;
 
         [NotMapped]
         public string RoomNumber { get; set; } = string.Empty;

--- a/DomainModels/Hotel.cs
+++ b/DomainModels/Hotel.cs
@@ -11,15 +11,15 @@ namespace Hotel_Booking_System.DomainModels
     public class Hotel
     {
         [Key]
-        public string HotelID { get; set; }
-        public string UserID { get; set; }
-        public string HotelName { get; set; }
-        public string Address { get; set; }
-        public string City { get; set; }
-        public string HotelImage { get; set; }
+        public string HotelID { get; set; } = string.Empty;
+        public string UserID { get; set; } = string.Empty;
+        public string HotelName { get; set; } = string.Empty;
+        public string Address { get; set; } = string.Empty;
+        public string City { get; set; } = string.Empty;
+        public string HotelImage { get; set; } = string.Empty;
         public double MinPrice { get; set; }
         public double MaxPrice { get; set; }
-        public string Description { get; set; }
+        public string Description { get; set; } = string.Empty;
         public int Rating { get; set; }
         public bool IsApproved { get; set; }
         public bool IsVisible { get; set; } = true;

--- a/DomainModels/HotelAdminRequest.cs
+++ b/DomainModels/HotelAdminRequest.cs
@@ -10,12 +10,12 @@ namespace Hotel_Booking_System.DomainModels
     public class HotelAdminRequest
     {
         [Key]
-        public string RequestID { get; set; }
-        public string UserID { get; set; }
-        public string HotelName { get; set; }
-        public string HotelAddress { get; set; }
-        public string Reason { get; set; }
-        public string Status { get; set; }
+        public string RequestID { get; set; } = string.Empty;
+        public string UserID { get; set; } = string.Empty;
+        public string HotelName { get; set; } = string.Empty;
+        public string HotelAddress { get; set; } = string.Empty;
+        public string Reason { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
     }
 }

--- a/DomainModels/Payment.cs
+++ b/DomainModels/Payment.cs
@@ -10,10 +10,10 @@ namespace Hotel_Booking_System.DomainModels
     public class Payment
     {
         [Key]
-        public string PaymentID { get; set; }
-        public string BookingID { get; set; } = "";
+        public string PaymentID { get; set; } = string.Empty;
+        public string BookingID { get; set; } = string.Empty;
         public double TotalPayment { get; set; }
-        public string Method { get; set; }
+        public string Method { get; set; } = string.Empty;
         public DateTime PaymentDate { get; set; }
     }
 }

--- a/DomainModels/Review.cs
+++ b/DomainModels/Review.cs
@@ -12,13 +12,13 @@ namespace Hotel_Booking_System.DomainModels
     public class Review : INotifyPropertyChanged
     {
         [Key]
-        public string ReviewID { get; set; }
-        public string UserID { get; set; }
-        public string HotelID { get; set; }
-        public string RoomID { get; set; }
-        public string BookingID { get; set; }
+        public string ReviewID { get; set; } = string.Empty;
+        public string UserID { get; set; } = string.Empty;
+        public string HotelID { get; set; } = string.Empty;
+        public string RoomID { get; set; } = string.Empty;
+        public string BookingID { get; set; } = string.Empty;
         public int Rating { get; set; }
-        public string Comment { get; set; }
+        public string Comment { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
 
         private string? _adminReply;

--- a/DomainModels/Room.cs
+++ b/DomainModels/Room.cs
@@ -11,9 +11,9 @@ namespace Hotel_Booking_System.DomainModels
     public class Room : INotifyPropertyChanged
     {
         [Key]
-        public string RoomID { get; set; }
-        public string HotelID { get; set; } = "";
-        public string RoomNumber { get; set; } = "";
+        public string RoomID { get; set; } = string.Empty;
+        public string HotelID { get; set; } = string.Empty;
+        public string RoomNumber { get; set; } = string.Empty;
 
         private string _roomImage = string.Empty;
         public string RoomImage
@@ -29,10 +29,10 @@ namespace Hotel_Booking_System.DomainModels
             }
         }
 
-        public string RoomType { get; set; } = "";
+        public string RoomType { get; set; } = string.Empty;
         public int Capacity { get; set; }
         public double PricePerNight { get; set; }
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
 
         public event PropertyChangedEventHandler? PropertyChanged;
     }

--- a/DomainModels/User.cs
+++ b/DomainModels/User.cs
@@ -12,14 +12,14 @@ namespace Hotel_Booking_System.DomainModels
     {
         
         [Key]
-        public string UserID { get; set; }
-        public string FullName { get; set; } = "";
+        public string UserID { get; set; } = string.Empty;
+        public string FullName { get; set; } = string.Empty;
         public string AvatarUrl { get; set; } = "https://i.ibb.co/FLvg0hX4/avatar-default.png";
-        public string Phone { get; set; } = "";
+        public string Phone { get; set; } = string.Empty;
         public DateTime DateOfBirth { get; set; }
-        public string Gender { get; set; } = "";
-        public string Email { get; set; } = "";
-        public string Password { get; set; } = "";
-        public string Role { get; set; } = "";
+        public string Gender { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
     }
 }

--- a/Hotel_Booking_System.csproj
+++ b/Hotel_Booking_System.csproj
@@ -15,14 +15,10 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="LiveChartsCore" Version="2.5.0" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.5.0" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.5.0" />
+    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Mscc.GenerativeAI" Version="2.8.9" />
-    <PackageReference Include="SkiaSharp" Version="2.88.7" />
-    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Hotel_Booking_System.csproj
+++ b/Hotel_Booking_System.csproj
@@ -15,10 +15,14 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc6.1" />
+    <PackageReference Include="LiveChartsCore" Version="2.5.0" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.5.0" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Mscc.GenerativeAI" Version="2.8.9" />
+    <PackageReference Include="SkiaSharp" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Interfaces/IBookingRepository.cs
+++ b/Interfaces/IBookingRepository.cs
@@ -9,6 +9,6 @@ namespace Hotel_Booking_System.Interfaces
 {
     public interface IBookingRepository : IRepository<Booking>
     {
-        Task<List<Booking?>> GetBookingByUserId(string userId);
+        Task<List<Booking>> GetBookingByUserId(string userId);
     }
 }

--- a/Repository/BookingRepository.cs
+++ b/Repository/BookingRepository.cs
@@ -31,7 +31,7 @@ namespace Hotel_Booking_System.Repository
 
         public Task<List<Booking>> GetAllAsync() => _context.Bookings.ToListAsync();
 
-        public Task<List<Booking?>> GetBookingByUserId(string userId) => _context.Bookings.Where(b => b.UserID == userId).ToListAsync();
+        public Task<List<Booking>> GetBookingByUserId(string userId) => _context.Bookings.Where(b => b.UserID == userId).ToListAsync();
 
         public Task<Booking?> GetByIdAsync(string id) => _context.Bookings.FirstOrDefaultAsync(r => r.BookingID == id);
 

--- a/ViewModels/BookingViewModel.cs
+++ b/ViewModels/BookingViewModel.cs
@@ -21,7 +21,7 @@ namespace Hotel_Booking_System.ViewModels
         private int _numberOfGuests;
         private string _guestName = string.Empty;
         private double _totalPayment;
-        private string _notificationMessage;
+        private string _notificationMessage = string.Empty;
         private string _notificationVisibility = "Collapsed";
 
         public BookingViewModel(IBookingRepository bookingRepository, IRoomRepository roomRepository, INavigationService navigationService)
@@ -66,9 +66,9 @@ namespace Hotel_Booking_System.ViewModels
                 CalculateTotalPayment();
             }
         }
-        public Room SelectedRoom { get ; set ; }
-        public User CurrentUser { get ; set ; }
-        public Hotel Hotel { get ; set ; }
+        public Room? SelectedRoom { get; set; }
+        public User? CurrentUser { get; set; }
+        public Hotel? Hotel { get; set; }
 
         public string NotificationMessage
         {
@@ -102,7 +102,7 @@ namespace Hotel_Booking_System.ViewModels
         [RelayCommand]
         private async Task ConfirmBooking()
         {
-            if (SelectedRoom == null || CurrentUser == null)
+            if (SelectedRoom == null || CurrentUser == null || Hotel == null)
                 return;
 
             NotificationMessage = string.Empty;

--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -929,7 +929,7 @@ namespace Hotel_Booking_System.ViewModels
             {
                 Background = OxyColors.Transparent,
                 TextColor = OxyColor.FromRgb(66, 66, 66),
-                PlotAreaBorderColor = OxyColor.FromAColor(0, 0, 0, 0)
+                PlotAreaBorderColor = OxyColor.FromArgb(0, 0, 0, 0)
             };
 
             var xAxis = new CategoryAxis
@@ -955,7 +955,7 @@ namespace Hotel_Booking_System.ViewModels
                 IsZoomEnabled = false,
                 IsPanEnabled = false,
                 MajorGridlineStyle = LineStyle.Solid,
-                MajorGridlineColor = OxyColor.FromAColor(40, 158, 158, 158),
+                MajorGridlineColor = OxyColor.FromArgb(40, 158, 158, 158),
                 MinorGridlineStyle = LineStyle.None,
                 StringFormat = "N0"
             };

--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -846,19 +846,25 @@ namespace Hotel_Booking_System.ViewModels
         {
             if (SelectedRevenueFilter == null)
             {
-                RevenuePlotModel = CreateEmptyRevenuePlotModel();
+                var emptyModel = CreateEmptyRevenuePlotModel();
+                emptyModel.InvalidatePlot(true);
+                RevenuePlotModel = emptyModel;
                 RevenueSummary = "Chưa có dữ liệu doanh thu.";
                 return;
             }
 
             if (!_revenueData.TryGetValue(SelectedRevenueFilter.Range, out var data) || data.Count == 0)
             {
-                RevenuePlotModel = CreateEmptyRevenuePlotModel();
+                var emptyModel = CreateEmptyRevenuePlotModel();
+                emptyModel.InvalidatePlot(true);
+                RevenuePlotModel = emptyModel;
                 RevenueSummary = "Chưa có dữ liệu doanh thu.";
                 return;
             }
 
-            RevenuePlotModel = CreateRevenuePlotModel(data);
+            var model = CreateRevenuePlotModel(data);
+            model.InvalidatePlot(true);
+            RevenuePlotModel = model;
 
             var firstDate = data.First().Timestamp;
             var lastDate = data.Last().Timestamp;

--- a/ViewModels/SuperAdminViewModel.cs
+++ b/ViewModels/SuperAdminViewModel.cs
@@ -20,13 +20,13 @@ namespace Hotel_Booking_System.ViewModels
 {
     public partial class SuperAdminViewModel : Bindable, ISuperAdminViewModel
     {
-        private string _userEmail;
+        private string _userEmail = string.Empty;
         private IRoomRepository _roomRepository;
         private IHotelAdminRequestRepository _hotelAdminRequestRepository;
         private IHotelRepository _hotelRepository;
         private IUserRepository _userRepository;
         private INavigationService _navigationService;
-        private User _currentUser;
+        private User _currentUser = new();
         private int _totalHotels;
         private int _totalUsers;
         private int _pendingRequests;
@@ -57,8 +57,8 @@ namespace Hotel_Booking_System.ViewModels
         
 
         public ObservableCollection<HotelAdminRequest> PendingRequest { get; set; } = new();
-        public ObservableCollection<User> Users { get; set; }
-        public ObservableCollection<Hotel> Hotels { get; set; }
+        public ObservableCollection<User> Users { get; set; } = new();
+        public ObservableCollection<Hotel> Hotels { get; set; } = new();
         public ObservableCollection<Hotel> PendingHotels { get; set; } = new();
         public SuperAdminViewModel(IRoomRepository roomRepository, IHotelAdminRequestRepository hotelAdminRequestRepository, IHotelRepository hotelRepository, IUserRepository userRepository, INavigationService navigationService)
         {
@@ -113,7 +113,11 @@ namespace Hotel_Booking_System.ViewModels
 
         private async Task GetCurrentUserAsync()
         {
-            CurrentUser = await _userRepository.GetByEmailAsync(_userEmail);
+            var user = await _userRepository.GetByEmailAsync(_userEmail);
+            if (user != null)
+            {
+                CurrentUser = user;
+            }
         }
 
         [RelayCommand]

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -33,7 +33,7 @@ namespace Hotel_Booking_System.ViewModels
         private readonly IAIChatRepository _aiChatRepository;
         private readonly IReviewRepository _reviewRepository;
 
-        private string userMail;
+        private string userMail = string.Empty;
         private int _totalBookings;
         private double _totalSpent;
         private string _showSearchRoom = "Collapsed";
@@ -45,19 +45,19 @@ namespace Hotel_Booking_System.ViewModels
         private string _showRegisterForm = "Collapsed";
         private string _showChatBox = "Collapsed";
         private string _showChatButton = "Visible";
-        private Hotel _currentHotel;
-        private User _currentUser;
+        private Hotel _currentHotel = new();
+        private User _currentUser = new();
         private string _errorVisibility = "Collapsed";
         private string _errorMessage = string.Empty;
         private string _requestHotelName = "";
         private string _requestHotelAddress = "";
         private string _requestReason = "";
-        private string _selectedModel;
+        private string _selectedModel = string.Empty;
         private string _chatInput = string.Empty;
         private string _membershipLevel = "Bronze";
         private string _hasBookings = "Collapsed";
 
-        private DispatcherTimer _typingTimer;
+        private DispatcherTimer? _typingTimer;
 
         private string _currentPassword = string.Empty;
         private string _newPassword = string.Empty;
@@ -157,19 +157,19 @@ namespace Hotel_Booking_System.ViewModels
         {
             get;
             set;
-        }
+        } = new();
 
         public ObservableCollection<Room> Rooms
         {
             get;
             set;
-        }
+        } = new();
 
         public ObservableCollection<Room> FilteredRooms
         {
             get;
             set;
-        }
+        } = new();
 
         public string ErrorVisibility { get => _errorVisibility; set => Set(ref _errorVisibility, value); }
         public string ErrorMessage { get => _errorMessage; set => Set(ref _errorMessage, value); }
@@ -666,7 +666,11 @@ namespace Hotel_Booking_System.ViewModels
             {
                 CurrentUser.AvatarUrl = await UploadImageService.UploadAsync(openFileDialog.FileName);
                 await _userRepository.UpdateAsync(CurrentUser);
-                CurrentUser = await _userRepository.GetByIdAsync(CurrentUser.UserID);
+                var refreshed = await _userRepository.GetByIdAsync(CurrentUser.UserID);
+                if (refreshed != null)
+                {
+                    CurrentUser = refreshed;
+                }
             }
         }
 
@@ -734,6 +738,11 @@ namespace Hotel_Booking_System.ViewModels
         private void BookRoom(Room room)
         {
             var hotel = Hotels.FirstOrDefault(h => h.HotelID == room.HotelID);
+            if (hotel == null)
+            {
+                return;
+            }
+
             bool res = _navigationService.OpenBookingDialog(room, CurrentUser, hotel);
 
             if (res)

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -303,6 +303,8 @@
                                 </StackPanel>
 
                                 <oxy:PlotView Margin="0,20,0,16"
+                                              Height="360"
+                                              MinHeight="280"
                                               Model="{Binding RevenuePlotModel}"
                                               Background="Transparent"/>
 

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Hotel_Booking_System.Views"
-        xmlns:lvc="http://schemas.livecharts.com/wpf"
+        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
         mc:Ignorable="d"
             Title="Multi-Hotel Booking System" Height="900" Width="1400"
         WindowState="Maximized"

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -306,9 +306,7 @@
                                                     Series="{Binding RevenueSeries}"
                                                     XAxes="{Binding RevenueXAxes}"
                                                     YAxes="{Binding RevenueYAxes}"
-                                                    ZoomMode="X"
-                                                    AnimationsSpeed="0:0:0.6"
-                                                    LegendPosition="Hidden"/>
+                                                    AnimationsSpeed="0:0:0.6"/>
 
                                 <TextBlock Text="{Binding RevenueSummary}"
                                            FontSize="16"

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Hotel_Booking_System.Views"
-        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+        xmlns:oxy="http://oxyplot.org/wpf"
         mc:Ignorable="d"
             Title="Multi-Hotel Booking System" Height="900" Width="1400"
         WindowState="Maximized"
@@ -302,11 +302,9 @@
                                               DisplayMemberPath="DisplayName"/>
                                 </StackPanel>
 
-                                <lvc:CartesianChart Margin="0,20,0,16"
-                                                    Series="{Binding RevenueSeries}"
-                                                    XAxes="{Binding RevenueXAxes}"
-                                                    YAxes="{Binding RevenueYAxes}"
-                                                    AnimationsSpeed="0:0:0.6"/>
+                                <oxy:PlotView Margin="0,20,0,16"
+                                              Model="{Binding RevenuePlotModel}"
+                                              Background="Transparent"/>
 
                                 <TextBlock Text="{Binding RevenueSummary}"
                                            FontSize="16"


### PR DESCRIPTION
## Summary
- initialize string properties across the domain models to comply with nullable reference type rules
- repair the hotel admin revenue analytics by removing the unsupported tooltip formatter, refreshing yearly summaries, and updating the LiveCharts namespace
- harden view models, repository contracts, and dependency injection accessors to avoid null-related build errors

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0fde6e24833398a6fe2248e6d8fb