### PR TITLE
Add hotel reviews dialog with filtering

### DIFF
--- a/ViewModels/HotelReviewsViewModel.cs
+++ b/ViewModels/HotelReviewsViewModel.cs
@@ -1,0 +1,193 @@
+using Hotel_Booking_System.DomainModels;
+using Hotel_Booking_System.Interfaces;
+using Hotel_Manager.FrameWorks;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Hotel_Booking_System.ViewModels
+{
+    public class HotelReviewsViewModel : Bindable
+    {
+        private readonly IReviewRepository _reviewRepository;
+        private readonly IUserRepository _userRepository;
+
+        private readonly ObservableCollection<string> _ratingFilters = new()
+        {
+            "Tất cả",
+            "5 sao",
+            "4 sao",
+            "3 sao",
+            "2 sao",
+            "1 sao"
+        };
+
+        private List<Review> _allReviews = new();
+        private string _selectedRatingFilter;
+        private string _searchKeyword = string.Empty;
+        private string _emptyStateVisibility = "Collapsed";
+        private string _reviewListVisibility = "Collapsed";
+        private string _hotelName = string.Empty;
+
+        public HotelReviewsViewModel(IReviewRepository reviewRepository, IUserRepository userRepository)
+        {
+            _reviewRepository = reviewRepository;
+            _userRepository = userRepository;
+            _selectedRatingFilter = _ratingFilters.First();
+        }
+
+        public ObservableCollection<Review> Reviews { get; } = new();
+
+        public ObservableCollection<string> RatingFilters => _ratingFilters;
+
+        public string SelectedRatingFilter
+        {
+            get => _selectedRatingFilter;
+            set
+            {
+                if (_selectedRatingFilter == value)
+                {
+                    return;
+                }
+
+                Set(ref _selectedRatingFilter, value);
+                ApplyFilters();
+            }
+        }
+
+        public string SearchKeyword
+        {
+            get => _searchKeyword;
+            set
+            {
+                if (_searchKeyword == value)
+                {
+                    return;
+                }
+
+                Set(ref _searchKeyword, value);
+                ApplyFilters();
+            }
+        }
+
+        public string EmptyStateVisibility
+        {
+            get => _emptyStateVisibility;
+            private set => Set(ref _emptyStateVisibility, value);
+        }
+
+        public string HotelName
+        {
+            get => _hotelName;
+            private set => Set(ref _hotelName, value);
+        }
+
+        public string ReviewListVisibility
+        {
+            get => _reviewListVisibility;
+            private set => Set(ref _reviewListVisibility, value);
+        }
+
+        public async Task InitializeAsync(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            HotelName = hotel.HotelName;
+            await LoadReviewsAsync(hotel.HotelID);
+        }
+
+        private async Task LoadReviewsAsync(string hotelId)
+        {
+            var reviews = await _reviewRepository.GetAllAsync();
+            var hotelReviews = reviews
+                .Where(r => r.HotelID == hotelId)
+                .OrderByDescending(r => r.CreatedAt)
+                .ToList();
+
+            if (hotelReviews.Count == 0)
+            {
+                _allReviews = new List<Review>();
+                ApplyFilters();
+                return;
+            }
+
+            var userIds = hotelReviews
+                .Select(r => r.UserID)
+                .Distinct()
+                .ToList();
+
+            var userTasks = userIds
+                .Select(id => _userRepository.GetByIdAsync(id));
+
+            var users = await Task.WhenAll(userTasks);
+            var userLookup = users
+                .Where(u => u != null)
+                .Cast<User>()
+                .ToDictionary(u => u.UserID, u => u);
+
+            foreach (var review in hotelReviews)
+            {
+                if (userLookup.TryGetValue(review.UserID, out var user))
+                {
+                    review.ReviewerName = user.FullName;
+                    review.ReviewerAvatarUrl = user.AvatarUrl;
+                }
+
+                review.AdminReplyDraft = string.Empty;
+            }
+
+            _allReviews = hotelReviews;
+            ApplyFilters();
+        }
+
+        private void ApplyFilters()
+        {
+            Reviews.Clear();
+
+            IEnumerable<Review> filtered = _allReviews;
+
+            var rating = GetRatingFromFilter();
+            if (rating.HasValue)
+            {
+                filtered = filtered.Where(r => r.Rating == rating.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(SearchKeyword))
+            {
+                var keyword = SearchKeyword.Trim();
+                filtered = filtered.Where(r =>
+                    (!string.IsNullOrEmpty(r.Comment) && r.Comment.Contains(keyword, StringComparison.OrdinalIgnoreCase)) ||
+                    (!string.IsNullOrEmpty(r.ReviewerName) && r.ReviewerName.Contains(keyword, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            foreach (var review in filtered)
+            {
+                Reviews.Add(review);
+            }
+
+            EmptyStateVisibility = Reviews.Count == 0 ? "Visible" : "Collapsed";
+            ReviewListVisibility = Reviews.Count == 0 ? "Collapsed" : "Visible";
+        }
+
+        private int? GetRatingFromFilter()
+        {
+            if (string.IsNullOrWhiteSpace(SelectedRatingFilter) || SelectedRatingFilter.Equals(_ratingFilters.First(), StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var digits = new string(SelectedRatingFilter.Where(char.IsDigit).ToArray());
+            if (int.TryParse(digits, out var rating) && rating >= 1 && rating <= 5)
+            {
+                return rating;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Views/HotelReviewsWindow.xaml
+++ b/Views/HotelReviewsWindow.xaml
@@ -1,0 +1,173 @@
+<Window x:Class="Hotel_Booking_System.Views.HotelReviewsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Đánh giá khách sạn"
+        Height="600"
+        Width="640"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent">
+    <Border CornerRadius="16" Background="White" Padding="24" SnapsToDevicePixels="True">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="20" ShadowDepth="0" Opacity="0.25"/>
+        </Border.Effect>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Đánh giá khách sạn" FontSize="22" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding HotelName, StringFormat='Dành cho {0}'}" FontSize="12" Foreground="#FF616161" Margin="0,4,0,0"/>
+                </StackPanel>
+                <Button Grid.Column="1"
+                        x:Name="CloseButton"
+                        Content="✕"
+                        Width="32"
+                        Height="32"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        Foreground="#FF424242"
+                        FontSize="14"
+                        FontWeight="Bold"
+                        HorizontalAlignment="Right"
+                        Cursor="Hand"/>
+            </Grid>
+
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,20,0,16">
+                <StackPanel Width="200">
+                    <TextBlock Text="Lọc theo số sao" FontSize="12" Foreground="#FF757575" Margin="0,0,0,6"/>
+                    <ComboBox ItemsSource="{Binding RatingFilters}"
+                              SelectedItem="{Binding SelectedRatingFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              Height="32"/>
+                </StackPanel>
+                <StackPanel Margin="20,0,0,0" Width="240">
+                    <TextBlock Text="Tìm kiếm" FontSize="12" Foreground="#FF757575" Margin="0,0,0,6"/>
+                    <TextBox Text="{Binding SearchKeyword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                             Height="32"
+                             ToolTip="Nhập tên hoặc nội dung"/>
+                </StackPanel>
+            </StackPanel>
+
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0"
+                           Text="{Binding Reviews.Count, StringFormat='Tổng cộng {0} đánh giá'}"
+                           FontWeight="SemiBold"
+                           Margin="0,0,0,12"/>
+
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="{Binding ReviewListVisibility}">
+                    <ItemsControl ItemsSource="{Binding Reviews}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="#FFE0E0E0"
+                                        BorderThickness="0,0,0,1"
+                                        Padding="0,16"
+                                        Margin="0,0,0,8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <Border Width="44"
+                                                Height="44"
+                                                CornerRadius="22"
+                                                Background="#FFE0E0E0"
+                                                ClipToBounds="True"
+                                                Margin="0,0,12,0">
+                                            <Image Source="{Binding ReviewerAvatarUrl}" Stretch="UniformToFill"/>
+                                        </Border>
+
+                                        <StackPanel Grid.Column="1">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Text="{Binding ReviewerName}" FontWeight="Bold" FontSize="14"/>
+                                                <TextBlock Grid.Column="1"
+                                                           Text="{Binding CreatedAt, StringFormat='{}{0:dd/MM/yyyy}'}"
+                                                           FontSize="12"
+                                                           Foreground="#FF757575"/>
+                                            </Grid>
+                                            <TextBlock Text="{Binding Rating, StringFormat='{}{0}/5 ⭐'}"
+                                                       Foreground="#FFFF9800"
+                                                       FontWeight="SemiBold"
+                                                       Margin="0,4,0,0"/>
+                                            <TextBlock Text="{Binding Comment}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,6,0,0"/>
+                                            <Border Background="#FFF3E5F5"
+                                                    BorderBrush="#FFE0E0E0"
+                                                    BorderThickness="1"
+                                                    CornerRadius="6"
+                                                    Padding="10"
+                                                    Margin="0,10,0,0">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding AdminReply}" Value="">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding AdminReply}" Value="{x:Null}">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                                <StackPanel>
+                                                    <TextBlock Text="Phản hồi từ khách sạn"
+                                                               FontWeight="Bold"
+                                                               FontSize="12"
+                                                               Foreground="#FF6A1B9A"/>
+                                                    <TextBlock Text="{Binding AdminReply}"
+                                                               TextWrapping="Wrap"
+                                                               Margin="0,4,0,0"/>
+                                                </StackPanel>
+                                            </Border>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <TextBlock Grid.Row="1"
+                           Text="Chưa có đánh giá nào cho khách sạn này."
+                           Foreground="#FF757575"
+                           FontStyle="Italic"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding EmptyStateVisibility}"/>
+            </Grid>
+
+            <Button Grid.Row="3"
+                    Content="Đóng"
+                    HorizontalAlignment="Right"
+                    Width="100"
+                    Height="36"
+                    Margin="0,20,0,0"
+                    Background="#FF2196F3"
+                    Foreground="White"
+                    BorderBrush="Transparent"
+                    FontWeight="Bold"
+                    x:Name="CloseFooterButton"/>
+        </Grid>
+    </Border>
+</Window>

--- a/Views/HotelReviewsWindow.xaml.cs
+++ b/Views/HotelReviewsWindow.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+
+namespace Hotel_Booking_System.Views
+{
+    /// <summary>
+    /// Interaction logic for HotelReviewsWindow.xaml
+    /// </summary>
+    public partial class HotelReviewsWindow : Window
+    {
+        public HotelReviewsWindow()
+        {
+            InitializeComponent();
+            CloseButton.Click += (_, __) => Close();
+            CloseFooterButton.Click += (_, __) => Close();
+        }
+    }
+}

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -211,17 +211,15 @@
         Visibility="{Binding ShowRoomList}">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="8*"/>
-                                        <ColumnDefinition Width="389*"/>
+                                        <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                    
-                                    <Border Grid.Row="0" Background="#FF2196F3" CornerRadius="15,15,0,0" Grid.ColumnSpan="2">
+                                    <Border Grid.Row="0" Background="#FF2196F3" CornerRadius="15,15,0,0">
                                         <Grid Margin="20,15">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="*"/>
@@ -258,7 +256,7 @@
                                     </Border>
 
 
-                                    <ListView Grid.Row="1" Grid.Column="1"
+                                    <ListView Grid.Row="1"
           Margin="4,20,20,20"
           ItemsSource="{Binding FilteredRooms}"
           MaxHeight="400"
@@ -337,92 +335,6 @@
                                         </ListView.ItemTemplate>
                                     </ListView>
 
-                                    <ListView Grid.Row="2" Grid.Column="1"
-                                              Margin="4,0,20,20"
-                                              ItemsSource="{Binding Reviews}"
-                                              Background="Transparent"
-                                              BorderThickness="0"
-                                              MaxHeight="420"
-                                              ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                    <ListView.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border BorderBrush="#FFE0E0E0"
-                                                    BorderThickness="0,0,0,1"
-                                                    Padding="0,12"
-                                                    Margin="0,0,0,8">
-                                                <Grid>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="*"/>
-                                                    </Grid.ColumnDefinitions>
-
-                                                    <Border Width="44"
-                                                            Height="44"
-                                                            CornerRadius="22"
-                                                            Background="#FFE0E0E0"
-                                                            ClipToBounds="True"
-                                                            Margin="0,0,12,0">
-                                                        <Image Source="{Binding ReviewerAvatarUrl}"
-                                                               Stretch="UniformToFill"/>
-                                                    </Border>
-
-                                                    <StackPanel Grid.Column="1">
-                                                        <Grid>
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="*"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                            </Grid.ColumnDefinitions>
-                                                            <TextBlock Text="{Binding ReviewerName}"
-                                                                       FontWeight="Bold"
-                                                                       FontSize="14"/>
-                                                            <TextBlock Grid.Column="1"
-                                                                       Text="{Binding CreatedAt, StringFormat='{}{0:MMM dd, yyyy}'}"
-                                                                       FontSize="12"
-                                                                       Foreground="#FF757575"
-                                                                       HorizontalAlignment="Right"/>
-                                                        </Grid>
-                                                        <TextBlock Text="{Binding Rating, StringFormat='{}{0}/5 ⭐'}"
-                                                                   Foreground="#FFFF9800"
-                                                                   FontWeight="SemiBold"
-                                                                   Margin="0,4,0,0"/>
-                                                        <TextBlock Text="{Binding Comment}"
-                                                                   TextWrapping="Wrap"
-                                                                   Margin="0,6,0,0"/>
-                                                        <Border Background="#FFF3E5F5"
-                                                                BorderBrush="#FFE0E0E0"
-                                                                BorderThickness="1"
-                                                                CornerRadius="6"
-                                                                Padding="10"
-                                                                Margin="0,10,0,0">
-                                                            <Border.Style>
-                                                                <Style TargetType="Border">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                        <DataTrigger Binding="{Binding AdminReply}" Value="{x:Null}">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </Border.Style>
-                                                            <StackPanel>
-                                                                <TextBlock Text="Hotel response"
-                                                                           FontWeight="Bold"
-                                                                           FontSize="12"
-                                                                           Foreground="#FF6A1B9A"/>
-                                                                <TextBlock Text="{Binding AdminReply}"
-                                                                           TextWrapping="Wrap"
-                                                                           Margin="0,4,0,0"/>
-                                                            </StackPanel>
-                                                        </Border>
-                                                    </StackPanel>
-                                                </Grid>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ListView.ItemTemplate>
-                                    </ListView>
                                 </Grid>
                             </Border>
 
@@ -573,12 +485,17 @@
 
                                                 <StackPanel Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="20,15">
                                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                                        <Button Content="Details" 
-                                                    Style="{StaticResource PrimaryButton}"
-                                                    Width="80" 
-                                                    Command="{Binding DataContext.ShowHotelDetailsCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                    CommandParameter="{Binding HotelID}"
-                                                                />
+                                                        <Button Content="Reviews"
+                                                                Style="{StaticResource SecondaryButton}"
+                                                                Width="90"
+                                                                Margin="0,0,10,0"
+                                                                Command="{Binding DataContext.ShowHotelReviewsCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="Details"
+                                                                Style="{StaticResource PrimaryButton}"
+                                                                Width="80"
+                                                                Command="{Binding DataContext.ShowHotelDetailsCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                CommandParameter="{Binding HotelID}"/>
                                                     </StackPanel>
                                                 </StackPanel>
                                             </Grid>


### PR DESCRIPTION
## Summary
- add a Reviews button to each hotel card in the user view
- create a hotel reviews window that lists all feedback with rating and text search filters
- load review data asynchronously with reviewer details and show it in the dialog
- remove the inline reviews list from the hotel details pane so guests open the dedicated dialog instead

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da77506b7c833391ce739366fd38b5