### PR TITLE
Add inline notifications for hotel info updates

### DIFF
--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -1260,12 +1260,16 @@ namespace Hotel_Booking_System.ViewModels
         private async Task UpdateHotelInfo()
         {
             if (CurrentHotel == null)
+            {
+                ShowNotification("Please select a hotel to update.");
                 return;
+            }
 
             if (string.IsNullOrWhiteSpace(CurrentHotel.HotelName) ||
                 string.IsNullOrWhiteSpace(CurrentHotel.Address) ||
                 CurrentHotel.Rating < 1 || CurrentHotel.Rating > 5)
             {
+                ShowNotification("Please provide a hotel name, address, and rating between 1 and 5.");
                 return;
             }
 
@@ -1278,10 +1282,12 @@ namespace Hotel_Booking_System.ViewModels
                 await _hotelRepository.AddAsync(CurrentHotel);
                 await _hotelRepository.SaveAsync();
                 LoadHotels();
+                ShowNotification("Hotel information submitted successfully. An administrator will review the changes.");
             }
             else
             {
                 await _hotelRepository.UpdateAsync(CurrentHotel);
+                ShowNotification("Hotel information updated successfully.");
             }
         }
 

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -180,10 +180,18 @@
                                     </Grid>
                                 </Grid>
 
-                                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                                    <Button Content="Update Hotel Info" Width="180" Style="{StaticResource PrimaryButton}"
+                                <Grid Grid.Row="2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Text="{Binding NotificationMessage}" Foreground="#FF1976D2" FontSize="14"
+                                               VerticalAlignment="Center" Margin="0,0,10,0"/>
+
+                                    <Button Grid.Column="1" Content="Update Hotel Info" Width="180" Style="{StaticResource PrimaryButton}"
                                             Command="{Binding UpdateHotelInfoCommand}"/>
-                                </StackPanel>
+                                </Grid>
                             </Grid>
                         </Border>
 


### PR DESCRIPTION
## Summary
- display the current notification message inline with the hotel info update action
- surface success and validation feedback when saving hotel information

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db7c4b75e88333b8f7c2345156fb52