### PR TITLE
Improve super admin management workflows

### DIFF
--- a/ViewModels/SuperAdminViewModel.cs
+++ b/ViewModels/SuperAdminViewModel.cs
@@ -329,6 +329,55 @@ namespace Hotel_Booking_System.ViewModels
         }
 
         [RelayCommand]
+        private void ViewRequestDetails(HotelAdminRequest? request)
+        {
+            if (request == null)
+            {
+                return;
+            }
+
+            var applicant = Users.FirstOrDefault(u => u.UserID == request.UserID);
+            var applicantName = !string.IsNullOrWhiteSpace(request.ApplicantName)
+                ? request.ApplicantName
+                : applicant?.FullName ?? "Unknown";
+
+            var details = new StringBuilder();
+            details.AppendLine($"Applicant: {applicantName}");
+
+            if (applicant != null)
+            {
+                if (!string.IsNullOrWhiteSpace(applicant.Email))
+                {
+                    details.AppendLine($"Email: {applicant.Email}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(applicant.Phone))
+                {
+                    details.AppendLine($"Phone: {applicant.Phone}");
+                }
+            }
+
+            details.AppendLine($"Hotel: {request.HotelName}");
+            if (!string.IsNullOrWhiteSpace(request.HotelAddress))
+            {
+                details.AppendLine($"Address: {request.HotelAddress}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Reason))
+            {
+                details.AppendLine();
+                details.AppendLine("Reason provided:");
+                details.AppendLine(request.Reason);
+            }
+
+            details.AppendLine();
+            details.AppendLine($"Submitted: {request.CreatedAt:dd MMM yyyy}");
+            details.AppendLine($"Status: {request.Status}");
+
+            MessageBox.Show(details.ToString(), "Hotel Admin Request", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        [RelayCommand]
         private async Task ApproveRequest(string id)
         {
             var request = await _hotelAdminRequestRepository.GetByIdAsync(id);

--- a/ViewModels/SuperAdminViewModel.cs
+++ b/ViewModels/SuperAdminViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Mail;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
@@ -11,7 +13,9 @@ using CommunityToolkit.Mvvm.Messaging;
 using Hotel_Booking_System.DomainModels;
 using Hotel_Booking_System.Interfaces;
 using Hotel_Booking_System.Services;
+using Hotel_Booking_System.Views;
 using Hotel_Manager.FrameWorks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Win32;
 
 namespace Hotel_Booking_System.ViewModels
@@ -492,6 +496,211 @@ namespace Hotel_Booking_System.ViewModels
         }
 
         [RelayCommand]
+        private void ViewHotelDetails(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            var details = new StringBuilder();
+            details.AppendLine($"Name: {hotel.HotelName}");
+            details.AppendLine($"City: {hotel.City}");
+            details.AppendLine($"Address: {hotel.Address}");
+            details.AppendLine($"Status: {hotel.Status}");
+            details.AppendLine($"Total rooms: {hotel.TotalRooms}");
+            details.AppendLine($"Rating: {hotel.Rating}/5");
+
+            MessageBox.Show(details.ToString(), "Hotel Details", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        [RelayCommand]
+        private async Task EditHotelAsync(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var dialog = App.Provider?.GetRequiredService<AddHotelDialog>();
+                if (dialog == null)
+                {
+                    MessageBox.Show("Unable to open the edit dialog.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+
+                dialog.Title = "Edit Hotel";
+                var editableHotel = new Hotel
+                {
+                    HotelID = hotel.HotelID,
+                    UserID = hotel.UserID,
+                    HotelName = hotel.HotelName,
+                    Address = hotel.Address,
+                    City = hotel.City,
+                    Description = hotel.Description,
+                    Rating = hotel.Rating
+                };
+
+                dialog.DataContext = editableHotel;
+
+                if (dialog.ShowDialog() == true)
+                {
+                    hotel.HotelName = editableHotel.HotelName;
+                    hotel.Address = editableHotel.Address;
+                    hotel.City = editableHotel.City;
+                    hotel.Description = editableHotel.Description;
+                    hotel.Rating = editableHotel.Rating;
+
+                    await _hotelRepository.UpdateAsync(hotel);
+
+                    hotel.Status = GetHotelStatus(hotel);
+
+                    UpdateHotelStats();
+                    UpdateCityOptions();
+                    ApplyHotelFilters();
+
+                    MessageBox.Show($"Hotel \"{hotel.HotelName}\" was updated successfully.", "Hotel Updated", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to edit hotel: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private async Task ManageRoomsAsync(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var rooms = await _roomRepository.GetAllAsync();
+                var hotelRooms = rooms
+                    .Where(r => r.HotelID == hotel.HotelID)
+                    .OrderBy(r => r.RoomNumber)
+                    .ToList();
+
+                if (hotelRooms.Count == 0)
+                {
+                    MessageBox.Show($"{hotel.HotelName} does not have any rooms yet.", "Rooms Overview", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                var builder = new StringBuilder();
+                builder.AppendLine($"{hotel.HotelName} currently has {hotelRooms.Count} room(s):");
+                foreach (var room in hotelRooms.Take(10))
+                {
+                    builder.AppendLine($"• Room {room.RoomNumber} - {room.RoomType} ({room.PricePerNight:C})");
+                }
+
+                if (hotelRooms.Count > 10)
+                {
+                    builder.AppendLine($"…and {hotelRooms.Count - 10} more room(s).");
+                }
+
+                MessageBox.Show(builder.ToString(), "Rooms Overview", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to load rooms for {hotel.HotelName}: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private async Task ShowHotelAnalyticsAsync(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var rooms = await _roomRepository.GetAllAsync();
+                var hotelRooms = rooms.Where(r => r.HotelID == hotel.HotelID).ToList();
+
+                double minPrice = hotelRooms.Count > 0 ? hotelRooms.Min(r => r.PricePerNight) : 0;
+                double maxPrice = hotelRooms.Count > 0 ? hotelRooms.Max(r => r.PricePerNight) : 0;
+                double averagePrice = hotelRooms.Count > 0 ? hotelRooms.Average(r => r.PricePerNight) : 0;
+
+                var analytics = new StringBuilder();
+                analytics.AppendLine($"Hotel: {hotel.HotelName}");
+                analytics.AppendLine($"Status: {hotel.Status}");
+                analytics.AppendLine($"Total rooms: {hotelRooms.Count}");
+                analytics.AppendLine($"Average rating: {hotel.Rating}/5");
+                analytics.AppendLine($"Price range: {minPrice:C} - {maxPrice:C}");
+                analytics.AppendLine($"Average price: {averagePrice:C}");
+
+                MessageBox.Show(analytics.ToString(), "Hotel Analytics", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to load analytics for {hotel.HotelName}: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private async Task ToggleHotelVisibilityAsync(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            try
+            {
+                hotel.IsVisible = !hotel.IsVisible;
+                await _hotelRepository.UpdateAsync(hotel);
+
+                hotel.Status = GetHotelStatus(hotel);
+
+                UpdateHotelStats();
+                ApplyHotelFilters();
+
+                var state = hotel.IsVisible ? "activated" : "suspended";
+                MessageBox.Show($"Hotel \"{hotel.HotelName}\" has been {state}.", "Hotel Updated", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to update hotel visibility: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private void ContactHotelAdmin(Hotel? hotel)
+        {
+            if (hotel == null)
+            {
+                return;
+            }
+
+            var admin = Users.FirstOrDefault(u => u.UserID == hotel.UserID);
+            if (admin == null || string.IsNullOrWhiteSpace(admin.Email))
+            {
+                MessageBox.Show("This hotel does not have an associated admin email.", "Contact Admin", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                var subject = Uri.EscapeDataString($"Regarding {hotel.HotelName}");
+                var mailto = $"mailto:{admin.Email}?subject={subject}";
+
+                Process.Start(new ProcessStartInfo(mailto) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to open the default mail client: {ex.Message}", "Contact Admin", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
         private async Task ApproveHotel(string id)
         {
             var hotel = await _hotelRepository.GetByIdAsync(id);
@@ -657,6 +866,7 @@ namespace Hotel_Booking_System.ViewModels
         [RelayCommand]
         private void SearchHotels()
         {
+            HotelSearchTerm = HotelSearchTerm?.Trim() ?? string.Empty;
             ApplyHotelFilters();
         }
 
@@ -676,6 +886,118 @@ namespace Hotel_Booking_System.ViewModels
         private async Task RefreshHotelsAsync()
         {
             await LoadDataAsync();
+        }
+
+        [RelayCommand]
+        private void ViewUserDetails(User? user)
+        {
+            if (user == null)
+            {
+                return;
+            }
+
+            var builder = new StringBuilder();
+            builder.AppendLine($"Name: {user.FullName}");
+            builder.AppendLine($"Email: {user.Email}");
+            builder.AppendLine($"Phone: {user.Phone}");
+            builder.AppendLine($"Gender: {user.Gender}");
+            builder.AppendLine($"Role: {user.Role}");
+            builder.AppendLine($"Date of birth: {user.DateOfBirth:dd/MM/yyyy}");
+
+            MessageBox.Show(builder.ToString(), "User Details", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        [RelayCommand]
+        private async Task ChangeUserRole(User? user)
+        {
+            if (user == null)
+            {
+                return;
+            }
+
+            var message = $"The current role of {user.FullName} is \"{user.Role}\".\n\nSelect Yes to promote to Hotel Admin, No to assign the standard User role, or Cancel to keep the current role.";
+            var result = MessageBox.Show(message, "Change User Role", MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+
+            if (result == MessageBoxResult.Cancel)
+            {
+                return;
+            }
+
+            var newRole = result == MessageBoxResult.Yes ? "HotelAdmin" : "User";
+
+            if (string.Equals(user.Role, newRole, StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBox.Show($"{user.FullName} already has the role \"{newRole}\".", "No Changes", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                user.Role = newRole;
+                await _userRepository.UpdateAsync(user);
+                MessageBox.Show($"Updated {user.FullName}'s role to {newRole} successfully.", "Role Updated", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to update user role: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private async Task RemoveUserAsync(User? user)
+        {
+            if (user == null)
+            {
+                return;
+            }
+
+            var confirm = MessageBox.Show($"Are you sure you want to remove {user.FullName} from the system?", "Remove User", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            try
+            {
+                await _userRepository.DeleteAsync(user.UserID);
+                await _userRepository.SaveAsync();
+
+                Users.Remove(user);
+                TotalUsers = Users.Count;
+
+                MessageBox.Show($"{user.FullName} has been removed.", "User Removed", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to remove user: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private void ContactUser(User? user)
+        {
+            if (user == null || string.IsNullOrWhiteSpace(user.Email))
+            {
+                MessageBox.Show("This user does not have a valid email address.", "Contact User", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                var subject = Uri.EscapeDataString("Support from Hotel Booking System");
+                var mailto = $"mailto:{user.Email}?subject={subject}";
+                Process.Start(new ProcessStartInfo(mailto) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to open the default mail client: {ex.Message}", "Contact User", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        [RelayCommand]
+        private void Logout()
+        {
+            _navigationService.NavigateToLogin();
         }
 
         private static bool IsPasswordValid(string password)

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -34,7 +34,8 @@
                 <TextBlock Text="{Binding CurrentUser.FullName}" Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom"/>
 
                 <Button Content="Logout" Style="{StaticResource PrimaryButton}" Width="100"
-                       Background="#FFFF5722" Margin="5,0,0,0"/>
+                       Background="#FFFF5722" Margin="5,0,0,0"
+                       Command="{Binding LogoutCommand}"/>
             </StackPanel>
         </Grid>
 
@@ -314,18 +315,30 @@
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
-                                                        <Button Content="👁️" ToolTip="View Details" Style="{StaticResource SecondaryButton}" 
-                                                   Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="✏️" ToolTip="Edit Hotel" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="🏠" ToolTip="Manage Rooms" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="📊" ToolTip="Analytics" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FF9C27B0" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="⚠️" ToolTip="Suspend" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="📧" ToolTip="Contact Admin" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FF607D8B" Width="25" Height="25" Margin="2" FontSize="10"/>
+                                                        <Button Content="👁️" ToolTip="View Details" Style="{StaticResource SecondaryButton}"
+                                                   Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ViewHotelDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="✏️" ToolTip="Edit Hotel" Style="{StaticResource SecondaryButton}"
+                                                   Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.EditHotelAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="🏠" ToolTip="Manage Rooms" Style="{StaticResource SecondaryButton}"
+                                                   Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ManageRoomsAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="📊" ToolTip="Analytics" Style="{StaticResource SecondaryButton}"
+                                                   Background="#FF9C27B0" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ShowHotelAnalyticsAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="⚠️" ToolTip="Suspend / Activate" Style="{StaticResource SecondaryButton}"
+                                                   Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ToggleHotelVisibilityAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="📧" ToolTip="Contact Admin" Style="{StaticResource SecondaryButton}"
+                                                   Background="#FF607D8B" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ContactHotelAdminCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </DataGridTemplateColumn.CellTemplate>
@@ -416,26 +429,40 @@
 
                         <Border Style="{StaticResource CardStyle}">
                             <StackPanel Margin="25">
-                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False">
+                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False"
+                                          IsReadOnly="True" ItemsSource="{Binding Users}">
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Header="User ID" Width="80" Binding="{Binding UserId}"/>
-                                        <DataGridTextColumn Header="Name" Width="150" Binding="{Binding FullName}"/>
-                                        <DataGridTextColumn Header="Email" Width="200" Binding="{Binding Email}"/>
-                                        <DataGridTextColumn Header="Role" Width="100" Binding="{Binding Role}"/>
-                                        <DataGridTextColumn Header="Status" Width="80" Binding="{Binding Status}"/>
-                                        <DataGridTextColumn Header="Last Login" Width="100" Binding="{Binding LastLogin}"/>
+                                        <DataGridTextColumn Header="User ID" Width="100" Binding="{Binding UserID}"/>
+                                        <DataGridTextColumn Header="Name" Width="160" Binding="{Binding FullName}"/>
+                                        <DataGridTextColumn Header="Email" Width="220" Binding="{Binding Email}"/>
+                                        <DataGridTextColumn Header="Role" Width="120" Binding="{Binding Role}"/>
+                                        <DataGridTextColumn Header="Phone" Width="140" Binding="{Binding Phone}"/>
+                                        <DataGridTextColumn Header="Gender" Width="100" Binding="{Binding Gender}"/>
+                                        <DataGridTextColumn Header="Date of Birth" Width="140" Binding="{Binding DateOfBirth, StringFormat='{}{0:dd/MM/yyyy}'}"/>
                                         <DataGridTemplateColumn Header="Actions" Width="200">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
-                                                        <Button Content="👁️" Style="{StaticResource SecondaryButton}" 
-                                                               Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="✏️" Style="{StaticResource SecondaryButton}" 
-                                                               Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="🚫" Style="{StaticResource SecondaryButton}" 
-                                                               Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="📧" Style="{StaticResource SecondaryButton}" 
-                                                               Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"/>
+                                                        <Button Content="👁️" Style="{StaticResource SecondaryButton}"
+                                                               Width="25" Height="25" Margin="2" FontSize="10"
+                                                                ToolTip="View details"
+                                                                Command="{Binding DataContext.ViewUserDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="✏️" Style="{StaticResource SecondaryButton}"
+                                                               Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                ToolTip="Change role"
+                                                                Command="{Binding DataContext.ChangeUserRoleCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="🚫" Style="{StaticResource SecondaryButton}"
+                                                               Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                ToolTip="Remove user"
+                                                                Command="{Binding DataContext.RemoveUserAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="📧" Style="{StaticResource SecondaryButton}"
+                                                               Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                ToolTip="Contact user"
+                                                                Command="{Binding DataContext.ContactUserCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </DataGridTemplateColumn.CellTemplate>
@@ -682,27 +709,6 @@
                 </ScrollViewer>
 
             </TabItem>
-
-
-            <TabItem x:Name="PaymentSummaryTab" Header="💰 Payment Summary">
-                <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
-                    <StackPanel>
-                        <TextBlock Text="Payment Summary" Style="{StaticResource HeaderTextStyle}"/>
-                        <DataGrid ItemsSource="{Binding Payments}" AutoGenerateColumns="False" CanUserAddRows="False" Margin="0,20,0,20">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Payment ID" Binding="{Binding PaymentID}" Width="*"/>
-                                <DataGridTextColumn Header="Booking ID" Binding="{Binding BookingID}" Width="*"/>
-                                <DataGridTextColumn Header="Amount" Binding="{Binding TotalPayment}" Width="*"/>
-                                <DataGridTextColumn Header="Method" Binding="{Binding Method}" Width="*"/>
-                                <DataGridTextColumn Header="Date" Binding="{Binding PaymentDate}" Width="*"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                        <TextBlock Text="{Binding TotalRevenue, StringFormat='Total Revenue: ${0:F0}'}" FontSize="16" FontWeight="Bold" Foreground="#27AE60" HorizontalAlignment="Right"/>
-                    </StackPanel>
-                </ScrollViewer>
-            </TabItem>
-
-
         </TabControl>
     </Grid>
 </Window>

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -44,10 +44,10 @@
 
 
  
-            <TabItem Style="{StaticResource TabItemStyle}" x:Name="SuperAdminDashboard" Header="👑 System Overview" Visibility="Visible">
+            <TabItem Style="{StaticResource TabItemStyle}" x:Name="SuperAdminDashboard" Header="👑 Tổng quan hệ thống" Visibility="Visible">
                 <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
                     <StackPanel>
-                        <TextBlock Text="Super Admin Dashboard" Style="{StaticResource HeaderTextStyle}"/>
+                        <TextBlock Text="Bảng điều khiển Super Admin" Style="{StaticResource HeaderTextStyle}"/>
 
         
                         <Grid Margin="0,0,0,30">
@@ -62,35 +62,35 @@
                             <Border Grid.Column="0" Style="{StaticResource CardStyle}" Background="#FF4CAF50">
                                 <StackPanel Margin="15" HorizontalAlignment="Center">
                                     <TextBlock Text="{Binding TotalHotels}" FontSize="24" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Total Hotels" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
+                                    <TextBlock Text="Tổng số khách sạn" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
                                 </StackPanel>
                             </Border>
 
                             <Border Grid.Column="1" Style="{StaticResource CardStyle}" Background="#FF2196F3">
                                 <StackPanel Margin="15" HorizontalAlignment="Center">
                                     <TextBlock Text="{Binding TotalUsers}" FontSize="24" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Total Users" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
+                                    <TextBlock Text="Tổng số người dùng" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
                                 </StackPanel>
                             </Border>
 
                             <Border Grid.Column="2" Style="{StaticResource CardStyle}" Background="#FFFF9800">
                                 <StackPanel Margin="15" HorizontalAlignment="Center">
                                     <TextBlock Text="{Binding ActiveBookings}" FontSize="24" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Active Bookings" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
+                                    <TextBlock Text="Đặt phòng đang hoạt động" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
                                 </StackPanel>
                             </Border>
 
                             <Border Grid.Column="3" Style="{StaticResource CardStyle}" Background="#FFFF5722">
                                 <StackPanel Margin="15" HorizontalAlignment="Center">
                                     <TextBlock Text="{Binding MonthlyRevenue, StringFormat={}{0:C}}" FontSize="20" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Monthly Revenue" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
+                                    <TextBlock Text="Doanh thu hàng tháng" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
                                 </StackPanel>
                             </Border>
 
                             <Border Grid.Column="4" Style="{StaticResource CardStyle}" Background="#FF9C27B0">
                                 <StackPanel Margin="15" HorizontalAlignment="Center">
                                     <TextBlock Text="{Binding PendingApprovals}" FontSize="24" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Pending Approvals" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
+                                    <TextBlock Text="Đang chờ phê duyệt" Foreground="White" HorizontalAlignment="Center" FontSize="12"/>
                                 </StackPanel>
                             </Border>
                         </Grid>
@@ -102,9 +102,9 @@
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Pending Hotel Admin Requests" FontSize="18" FontWeight="Bold"/>
+                                    <TextBlock Text="Yêu cầu quản trị khách sạn đang chờ" FontSize="18" FontWeight="Bold"/>
                                     <Border Grid.Column="1" Background="#FFE3F2FD" Padding="10,4" CornerRadius="12" VerticalAlignment="Center">
-                                        <TextBlock Text="{Binding PendingRequest.Count, StringFormat=Pending: {0}}" FontSize="12" FontWeight="SemiBold" Foreground="#FF1976D2"/>
+                                        <TextBlock Text="{Binding PendingRequest.Count, StringFormat=Đang chờ: {0}}" FontSize="12" FontWeight="SemiBold" Foreground="#FF1976D2"/>
                                     </Border>
                                 </Grid>
 
@@ -134,9 +134,9 @@
                                                     </StackPanel>
 
                                                     <StackPanel Grid.Column="1" Margin="20,0,0,0">
-                                                        <TextBlock Text="Request Details" FontSize="13" FontWeight="Bold" Foreground="#FF424242"/>
-                                                        <TextBlock Text="{Binding RequestID, StringFormat=ID: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
-                                                        <TextBlock Text="{Binding CreatedAt, StringFormat=Submitted: {0:dd MMM yyyy}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="Chi tiết yêu cầu" FontSize="13" FontWeight="Bold" Foreground="#FF424242"/>
+                                                        <TextBlock Text="{Binding RequestID, StringFormat=Mã: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding CreatedAt, StringFormat=Ngày gửi: {0:dd MMM yyyy}}" Foreground="#FF424242" Margin="0,4,0,0"/>
                                                         <Border CornerRadius="10" Padding="8,4" HorizontalAlignment="Left" Margin="0,6,0,0">
                                                             <Border.Style>
                                                                 <Style TargetType="Border">
@@ -159,13 +159,13 @@
                                                     </StackPanel>
 
                                                     <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                                                        <Button Content="Details" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Margin="0,0,6,0"
+                                                        <Button Content="Chi tiết" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Margin="0,0,6,0"
                                                                 Command="{Binding DataContext.ViewRequestDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding}"/>
-                                                        <Button Content="Approve" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FF4CAF50" Margin="0,0,6,0"
+                                                        <Button Content="Phê duyệt" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FF4CAF50" Margin="0,0,6,0"
                                                                 Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding RequestID}"/>
-                                                        <Button Content="Reject" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FFFF5722"
+                                                        <Button Content="Từ chối" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FFFF5722"
                                                                 Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding RequestID}"/>
                                                     </StackPanel>
@@ -197,9 +197,9 @@
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Pending Hotels" FontSize="18" FontWeight="Bold"/>
+                                    <TextBlock Text="Khách sạn đang chờ" FontSize="18" FontWeight="Bold"/>
                                     <Border Grid.Column="1" Background="#FFF3E5F5" Padding="10,4" CornerRadius="12" VerticalAlignment="Center">
-                                        <TextBlock Text="{Binding PendingHotels.Count, StringFormat=Awaiting review: {0}}" FontSize="12" FontWeight="SemiBold" Foreground="#FF6A1B9A"/>
+                                        <TextBlock Text="{Binding PendingHotels.Count, StringFormat=Đang chờ duyệt: {0}}" FontSize="12" FontWeight="SemiBold" Foreground="#FF6A1B9A"/>
                                     </Border>
                                 </Grid>
 
@@ -229,33 +229,33 @@
                                                                 <ColumnDefinition Width="*"/>
                                                             </Grid.ColumnDefinitions>
                                                             <StackPanel Grid.Column="0">
-                                                                <TextBlock Text="Price Range" FontSize="12" FontWeight="Bold" Foreground="#FF424242"/>
+                                                                <TextBlock Text="Khoảng giá" FontSize="12" FontWeight="Bold" Foreground="#FF424242"/>
                                                                 <TextBlock Text="{Binding MinPrice, StringFormat={}{0:C}}" Foreground="#FF424242" Margin="0,2,0,0"/>
                                                             </StackPanel>
                                                             <StackPanel Grid.Column="1">
-                                                                <TextBlock Text="Max" FontSize="12" FontWeight="Bold" Foreground="#FF424242"/>
+                                                                <TextBlock Text="Tối đa" FontSize="12" FontWeight="Bold" Foreground="#FF424242"/>
                                                                 <TextBlock Text="{Binding MaxPrice, StringFormat={}{0:C}}" Foreground="#FF424242" Margin="0,2,0,0"/>
                                                             </StackPanel>
                                                         </Grid>
                                                     </StackPanel>
 
                                                     <StackPanel Grid.Column="1" Margin="20,0,0,0">
-                                                        <TextBlock Text="Hotel Details" FontSize="13" FontWeight="Bold" Foreground="#FF424242"/>
-                                                        <TextBlock Text="{Binding HotelID, StringFormat=ID: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
-                                                        <TextBlock Text="{Binding TotalRooms, StringFormat=Rooms: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="Thông tin khách sạn" FontSize="13" FontWeight="Bold" Foreground="#FF424242"/>
+                                                        <TextBlock Text="{Binding HotelID, StringFormat=Mã: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding TotalRooms, StringFormat=Số phòng: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
                                                         <Border CornerRadius="10" Padding="8,4" HorizontalAlignment="Left" Background="#FFEDE7F6" Margin="0,6,0,0">
                                                             <TextBlock Text="{Binding Status}" FontWeight="SemiBold" Foreground="#FF4A148C"/>
                                                         </Border>
                                                     </StackPanel>
 
                                                     <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                                                        <Button Content="View" Style="{StaticResource SecondaryButton}" Width="70" Height="28" Margin="0,0,6,0"
+                                                        <Button Content="Xem" Style="{StaticResource SecondaryButton}" Width="70" Height="28" Margin="0,0,6,0"
                                                                 Command="{Binding DataContext.ViewHotelDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding}"/>
-                                                        <Button Content="Approve" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FF4CAF50" Margin="0,0,6,0"
+                                                        <Button Content="Phê duyệt" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FF4CAF50" Margin="0,0,6,0"
                                                                 Command="{Binding DataContext.ApproveHotelCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding HotelID}"/>
-                                                        <Button Content="Reject" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FFFF5722"
+                                                        <Button Content="Từ chối" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FFFF5722"
                                                                 Command="{Binding DataContext.RejectHotelCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding HotelID}"/>
                                                     </StackPanel>
@@ -282,7 +282,7 @@
 
                         <Border Style="{StaticResource CardStyle}">
                             <StackPanel Margin="25">
-                                <TextBlock Text="System Reports and Analytics" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                                <TextBlock Text="Báo cáo và phân tích hệ thống" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
 
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -291,24 +291,24 @@
                                     </Grid.ColumnDefinitions>
 
                                     <StackPanel Grid.Column="0" Margin="0,0,15,0">
-                                        <Button Content="📊 Revenue Report" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="📊 Báo cáo doanh thu" Style="{StaticResource PrimaryButton}"
                                                HorizontalAlignment="Stretch" Margin="0,5"/>
-                                        <Button Content="🏨 Hotel Performance" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="🏨 Hiệu suất khách sạn" Style="{StaticResource PrimaryButton}"
                                                HorizontalAlignment="Stretch" Margin="0,5"/>
-                                        <Button Content="👥 User Analytics" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="👥 Phân tích người dùng" Style="{StaticResource PrimaryButton}"
                                                HorizontalAlignment="Stretch" Margin="0,5"/>
-                                        <Button Content="📋 Booking Trends" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="📋 Xu hướng đặt phòng" Style="{StaticResource PrimaryButton}"
                                                HorizontalAlignment="Stretch" Margin="0,5"/>
                                     </StackPanel>
 
                                     <StackPanel Grid.Column="1" Margin="15,0,0,0">
-                                        <Button Content="💰 Payment Summary" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="💰 Tổng quan thanh toán" Style="{StaticResource PrimaryButton}"
                                                HorizontalAlignment="Stretch" Margin="0,5"/>
-                                        <Button Content="⭐ Review Analysis" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="⭐ Phân tích đánh giá" Style="{StaticResource PrimaryButton}"
                                                HorizontalAlignment="Stretch" Margin="0,5"/>
-                                        <Button Content="🚨 System Issues" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="🚨 Sự cố hệ thống" Style="{StaticResource PrimaryButton}"
                                                Background="#FFFF5722" HorizontalAlignment="Stretch" Margin="0,5"/>
-                                        <Button Content="📤 Export All Data" Style="{StaticResource PrimaryButton}" 
+                                        <Button Content="📤 Xuất toàn bộ dữ liệu" Style="{StaticResource PrimaryButton}"
                                                Background="#FF4CAF50" HorizontalAlignment="Stretch" Margin="0,5"/>
                                     </StackPanel>
                                 </Grid>

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -97,64 +97,186 @@
 
                         <Border Style="{StaticResource CardStyle}" Margin="0,0,0,20">
                             <StackPanel Margin="25">
-                                <TextBlock Text="Pending Hotel Admin Requests" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="Pending Hotel Admin Requests" FontSize="18" FontWeight="Bold"/>
+                                    <Border Grid.Column="1" Background="#FFE3F2FD" Padding="10,4" CornerRadius="12" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding PendingRequest.Count, StringFormat=Pending: {0}}" FontSize="12" FontWeight="SemiBold" Foreground="#FF1976D2"/>
+                                    </Border>
+                                </Grid>
 
-                                <DataGrid Height="200" AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding PendingRequest}">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Request ID" Width="100" Binding="{Binding RequestID}"/>
-                                        <DataGridTextColumn Header="Applicant Name" Width="150" Binding="{Binding ApplicantName}"/>
-                                        <DataGridTextColumn Header="Hotel Name" Width="200" Binding="{Binding HotelName}"/>
-                                        <DataGridTextColumn Header="Hotel Address" Width="200" Binding="{Binding HotelAddress}"/>
-                                        <DataGridTextColumn Header="Date Applied" Width="150" Binding="{Binding CreatedAt, StringFormat={}{0:MMM dd, yyyy}}"/>
-                                        <DataGridTemplateColumn Header="Actions" Width="180">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <StackPanel Orientation="Horizontal">
-                                                        <Button Content="👁️ View" Style="{StaticResource SecondaryButton}"
-                                                               Width="45" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="✅ Approve" Style="{StaticResource SecondaryButton}"
-                                                               Background="#FF4CAF50" Width="55" Height="25" Margin="2" FontSize="10"
-                                                               Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                                               CommandParameter="{Binding RequestID}"/>
-                                                        <Button Content="❌ Reject" Style="{StaticResource SecondaryButton}"
-                                                               Background="#FFFF5722" Width="50" Height="25" Margin="2" FontSize="10"
-                                                               Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                                               CommandParameter="{Binding RequestID}"/>
+                                <ItemsControl ItemsSource="{Binding PendingRequest}" Margin="0,10,0,0">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Vertical"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border CornerRadius="14" BorderBrush="#FFE0E0E0" BorderThickness="1" Background="White" Padding="18" Margin="0,0,0,12">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="2*"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding ApplicantName}" FontSize="16" FontWeight="Bold"/>
+                                                        <TextBlock Text="{Binding HotelName}" FontWeight="SemiBold" Foreground="#FF1976D2" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding HotelAddress}" Foreground="#FF616161" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                                                        <Border Background="#FFF1F8E9" Padding="10,6" CornerRadius="10" Margin="0,8,0,0">
+                                                            <TextBlock Text="{Binding Reason}" Foreground="#FF33691E" TextWrapping="Wrap"/>
+                                                        </Border>
                                                     </StackPanel>
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>
+
+                                                    <StackPanel Grid.Column="1" Margin="20,0,0,0">
+                                                        <TextBlock Text="Request Details" FontSize="13" FontWeight="Bold" Foreground="#FF424242"/>
+                                                        <TextBlock Text="{Binding RequestID, StringFormat=ID: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding CreatedAt, StringFormat=Submitted: {0:dd MMM yyyy}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <Border CornerRadius="10" Padding="8,4" HorizontalAlignment="Left" Margin="0,6,0,0">
+                                                            <Border.Style>
+                                                                <Style TargetType="Border">
+                                                                    <Setter Property="Background" Value="#FFFFF8E1"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Pending">
+                                                                            <Setter Property="Background" Value="#FFFFF3E0"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Approved">
+                                                                            <Setter Property="Background" Value="#FFE8F5E9"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Rejected">
+                                                                            <Setter Property="Background" Value="#FFFFEBEE"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Border.Style>
+                                                            <TextBlock Text="{Binding Status}" FontWeight="SemiBold" Foreground="#FF424242"/>
+                                                        </Border>
+                                                    </StackPanel>
+
+                                                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                        <Button Content="Details" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Margin="0,0,6,0"
+                                                                Command="{Binding DataContext.ViewRequestDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="Approve" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FF4CAF50" Margin="0,0,6,0"
+                                                                Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding RequestID}"/>
+                                                        <Button Content="Reject" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FFFF5722"
+                                                                Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding RequestID}"/>
+                                                    </StackPanel>
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+
+                                <TextBlock Text="Không có yêu cầu nào đang chờ duyệt." HorizontalAlignment="Center" Foreground="#FF9E9E9E" FontStyle="Italic" Margin="0,10,0,0">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PendingRequest.Count}" Value="0">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </StackPanel>
                         </Border>
 
                         <Border Style="{StaticResource CardStyle}" Margin="0,0,0,20">
                             <StackPanel Margin="25">
-                                <TextBlock Text="Pending Hotels" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
-                                <DataGrid Height="200" AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding PendingHotels}">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Hotel ID" Width="100" Binding="{Binding HotelID}"/>
-                                        <DataGridTextColumn Header="Hotel Name" Width="200" Binding="{Binding HotelName}"/>
-                                        <DataGridTextColumn Header="City" Width="150" Binding="{Binding City}"/>
-                                        <DataGridTemplateColumn Header="Actions" Width="150">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <StackPanel Orientation="Horizontal">
-                                                        <Button Content="✅ Approve" Style="{StaticResource SecondaryButton}"
-                                                                Background="#FF4CAF50" Width="55" Height="25" Margin="2" FontSize="10"
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="Pending Hotels" FontSize="18" FontWeight="Bold"/>
+                                    <Border Grid.Column="1" Background="#FFF3E5F5" Padding="10,4" CornerRadius="12" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding PendingHotels.Count, StringFormat=Awaiting review: {0}}" FontSize="12" FontWeight="SemiBold" Foreground="#FF6A1B9A"/>
+                                    </Border>
+                                </Grid>
+
+                                <ItemsControl ItemsSource="{Binding PendingHotels}" Margin="0,10,0,0">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Vertical"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border CornerRadius="14" BorderBrush="#FFE0E0E0" BorderThickness="1" Background="White" Padding="18" Margin="0,0,0,12">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="2*"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding HotelName}" FontSize="16" FontWeight="Bold"/>
+                                                        <TextBlock Text="{Binding City}" FontWeight="SemiBold" Foreground="#FF6A1B9A" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding Address}" Foreground="#FF616161" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                                                        <Grid Margin="0,8,0,0">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <StackPanel Grid.Column="0">
+                                                                <TextBlock Text="Price Range" FontSize="12" FontWeight="Bold" Foreground="#FF424242"/>
+                                                                <TextBlock Text="{Binding MinPrice, StringFormat={}{0:C}}" Foreground="#FF424242" Margin="0,2,0,0"/>
+                                                            </StackPanel>
+                                                            <StackPanel Grid.Column="1">
+                                                                <TextBlock Text="Max" FontSize="12" FontWeight="Bold" Foreground="#FF424242"/>
+                                                                <TextBlock Text="{Binding MaxPrice, StringFormat={}{0:C}}" Foreground="#FF424242" Margin="0,2,0,0"/>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </StackPanel>
+
+                                                    <StackPanel Grid.Column="1" Margin="20,0,0,0">
+                                                        <TextBlock Text="Hotel Details" FontSize="13" FontWeight="Bold" Foreground="#FF424242"/>
+                                                        <TextBlock Text="{Binding HotelID, StringFormat=ID: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <TextBlock Text="{Binding TotalRooms, StringFormat=Rooms: {0}}" Foreground="#FF424242" Margin="0,4,0,0"/>
+                                                        <Border CornerRadius="10" Padding="8,4" HorizontalAlignment="Left" Background="#FFEDE7F6" Margin="0,6,0,0">
+                                                            <TextBlock Text="{Binding Status}" FontWeight="SemiBold" Foreground="#FF4A148C"/>
+                                                        </Border>
+                                                    </StackPanel>
+
+                                                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                        <Button Content="View" Style="{StaticResource SecondaryButton}" Width="70" Height="28" Margin="0,0,6,0"
+                                                                Command="{Binding DataContext.ViewHotelDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="Approve" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FF4CAF50" Margin="0,0,6,0"
                                                                 Command="{Binding DataContext.ApproveHotelCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding HotelID}"/>
-                                                        <Button Content="❌ Reject" Style="{StaticResource SecondaryButton}"
-                                                                Background="#FFFF5722" Width="50" Height="25" Margin="2" FontSize="10"
+                                                        <Button Content="Reject" Style="{StaticResource SecondaryButton}" Width="85" Height="28" Background="#FFFF5722"
                                                                 Command="{Binding DataContext.RejectHotelCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                                 CommandParameter="{Binding HotelID}"/>
                                                     </StackPanel>
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+
+                                <TextBlock Text="Không có khách sạn nào đang chờ phê duyệt." HorizontalAlignment="Center" Foreground="#FF9E9E9E" FontStyle="Italic" Margin="0,10,0,0">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PendingHotels.Count}" Value="0">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </StackPanel>
                         </Border>
 

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -10,14 +10,12 @@ namespace Hotel_Booking_System.Views
 {
     public partial class SuperAdminWindow : Window
     {
-        private readonly IPaymentViewModel _paymentViewModel = App.Provider.GetRequiredService<IPaymentViewModel>();
         private readonly ISuperAdminViewModel _superAdminViewModel = App.Provider.GetRequiredService<ISuperAdminViewModel>();
 
         public SuperAdminWindow()
         {
             InitializeComponent();
             DataContext = _superAdminViewModel;
-            PaymentSummaryTab.DataContext = _paymentViewModel;
 
             txtCurrentPassword.PasswordChanged += (s, e) =>
             {
@@ -41,7 +39,6 @@ namespace Hotel_Booking_System.Views
 
             Loaded += async (s, e) =>
             {
-                await _paymentViewModel.LoadPaymentsAsync();
                 await _superAdminViewModel.LoadDataAsync();
             };
         }


### PR DESCRIPTION
## Summary
- wire hotel management action buttons to view, edit, analyse, toggle visibility and contact admins
- update the super admin user management grid to display real data and support role changes, removal and contact actions
- remove the unused payment summary tab, add logout handling and tighten hotel search behaviour

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db7d673fc88333b2374fc7cd79b8a5