### PR TITLE
Add hotel deletion workflow to hotel admin dashboard

### DIFF
--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -232,9 +232,14 @@
                                     </StackPanel>
                                 </Grid>
 
-                                <Button Content="Update Hotel Info" Width="170" Style="{StaticResource PrimaryButton}"
-                                        Command="{Binding UpdateHotelInfoCommand}"
-                                   HorizontalAlignment="Left"/>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                                    <Button Content="Update Hotel Info" Width="170" Style="{StaticResource PrimaryButton}"
+                                            Command="{Binding UpdateHotelInfoCommand}"/>
+                                    <Button Content="Delete Hotel" Width="150" Margin="12,0,0,0"
+                                            Style="{StaticResource SecondaryButton}"
+                                            Background="#FFFF5722"
+                                            Command="{Binding DeleteHotelCommand}"/>
+                                </StackPanel>
                             </StackPanel>
                         </Border>
 


### PR DESCRIPTION
## Summary
- clear the hotel admin city list before reloading approved hotels
- add a command that removes the selected hotel and all related rooms, bookings, payments, and reviews
- expose a Delete Hotel button in the hotel admin dashboard

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deab7ae92083339f1fc9631e15103a