### PR TITLE
Redesign hotel admin booking management experience

### DIFF
--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -289,39 +289,270 @@
                 <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
                     <StackPanel>
                         <TextBlock Text="Booking Management" Style="{StaticResource HeaderTextStyle}"/>
+                        <TextBlock Text="Quản lý các yêu cầu đặt phòng với giao diện hiện đại, trực quan và dễ thao tác." Foreground="#FF666666" Margin="0,0,0,20" TextWrapping="Wrap"/>
 
-                        <Grid Margin="0,0,0,20">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <TextBlock Text="Filter by Status:" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                <ComboBox Width="200"
-                                          Style="{StaticResource ModernComboBox}"
-                                          ItemsSource="{Binding BookingStatusFilters}"
-                                          SelectedItem="{Binding SelectedBookingStatusFilter}"/>
-                            </StackPanel>
-                        </Grid>
+                        <WrapPanel Margin="0,0,0,10" ItemWidth="240">
+                            <Border Style="{StaticResource CardStyle}" Margin="0,0,20,20" Width="240">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                        <GradientStop Color="#FFE3F2FD" Offset="0"/>
+                                        <GradientStop Color="#FFCFE0FC" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <StackPanel Margin="20">
+                                    <TextBlock Text="📘" FontSize="26"/>
+                                    <TextBlock Text="{Binding HotelBookingsCount, FallbackValue=0}" FontSize="28" FontWeight="Bold" Margin="0,12,0,2"/>
+                                    <TextBlock Text="Tổng số đặt phòng" FontWeight="SemiBold" Foreground="#FF1E3A8A"/>
+                                    <TextBlock Text="Tất cả các đặt phòng của khách sạn hiện tại." FontSize="12" Foreground="#FF6B7280" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </Border>
 
-  
+                            <Border Style="{StaticResource CardStyle}" Margin="0,0,20,20" Width="240">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                        <GradientStop Color="#FFFFF4E5" Offset="0"/>
+                                        <GradientStop Color="#FFFFE0B2" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <StackPanel Margin="20">
+                                    <TextBlock Text="⏳" FontSize="26"/>
+                                    <TextBlock Text="{Binding PendingBookingsCount, FallbackValue=0}" FontSize="28" FontWeight="Bold" Margin="0,12,0,2"/>
+                                    <TextBlock Text="Chờ xác nhận" FontWeight="SemiBold" Foreground="#FFB26A00"/>
+                                    <TextBlock Text="Số lượng đặt phòng đang chờ phê duyệt." FontSize="12" Foreground="#FF6B7280" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Style="{StaticResource CardStyle}" Margin="0,0,20,20" Width="240">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                        <GradientStop Color="#FFE8F5E9" Offset="0"/>
+                                        <GradientStop Color="#FFC8E6C9" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <StackPanel Margin="20">
+                                    <TextBlock Text="✅" FontSize="26"/>
+                                    <TextBlock Text="{Binding ConfirmedBookingsCount, FallbackValue=0}" FontSize="28" FontWeight="Bold" Margin="0,12,0,2"/>
+                                    <TextBlock Text="Đã xác nhận" FontWeight="SemiBold" Foreground="#FF2E7D32"/>
+                                    <TextBlock Text="Đặt phòng đã được phê duyệt thành công." FontSize="12" Foreground="#FF6B7280" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Style="{StaticResource CardStyle}" Margin="0,0,20,20" Width="240">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                        <GradientStop Color="#FFFFEBEE" Offset="0"/>
+                                        <GradientStop Color="#FFFFCDD2" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <StackPanel Margin="20">
+                                    <TextBlock Text="⚠️" FontSize="26"/>
+                                    <TextBlock Text="{Binding CancellationRequestsCount, FallbackValue=0}" FontSize="28" FontWeight="Bold" Margin="0,12,0,2"/>
+                                    <TextBlock Text="Yêu cầu hủy" FontWeight="SemiBold" Foreground="#FFC62828"/>
+                                    <TextBlock Text="Số lượng khách đang yêu cầu hủy phòng." FontSize="12" Foreground="#FF6B7280" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Style="{StaticResource CardStyle}" Margin="0,0,20,20" Width="240">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                        <GradientStop Color="#FFEDE7F6" Offset="0"/>
+                                        <GradientStop Color="#FFD1C4E9" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <StackPanel Margin="20">
+                                    <TextBlock Text="🏨" FontSize="26"/>
+                                    <TextBlock Text="{Binding TodayCheckInsCount, FallbackValue=0}" FontSize="28" FontWeight="Bold" Margin="0,12,0,2"/>
+                                    <TextBlock Text="Check-in hôm nay" FontWeight="SemiBold" Foreground="#FF6A1B9A"/>
+                                    <TextBlock Text="Khách dự kiến nhận phòng trong ngày hôm nay." FontSize="12" Foreground="#FF6B7280" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </Border>
+                        </WrapPanel>
+
+        
+                        <Border Style="{StaticResource CardStyle}" Margin="0,10,0,20">
+                            <Grid Margin="20">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="2*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Border Grid.Column="0" Background="#FFF3F6FB" CornerRadius="12" Padding="0" Margin="0,0,20,0" VerticalAlignment="Center">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="🔍" FontSize="16" VerticalAlignment="Center" Margin="16,0,8,0"/>
+                                        <TextBox Grid.Column="1"
+                                                 Style="{StaticResource ModernTextBox}"
+                                                 BorderThickness="0"
+                                                 Background="Transparent"
+                                                 Padding="0"
+                                                 FontSize="14"
+                                                 VerticalContentAlignment="Center"
+                                                 Text="{Binding BookingSearchQuery, UpdateSourceTrigger=PropertyChanged}"
+                                                 ToolTip="Nhập mã đặt phòng, tên khách hoặc số phòng"/>
+                                    </Grid>
+                                </Border>
+
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="Trạng thái" FontWeight="SemiBold" Foreground="#FF424242"/>
+                                    <ComboBox Style="{StaticResource ModernComboBox}"
+                                              ItemsSource="{Binding BookingStatusFilters}"
+                                              SelectedItem="{Binding SelectedBookingStatusFilter}"
+                                              Margin="0,6,0,0"
+                                              MinWidth="200"/>
+                                </StackPanel>
+
+                                <Button Grid.Column="2"
+                                        Content="🔄 Làm mới"
+                                        Margin="20,0,0,0"
+                                        Padding="20,10"
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Command="{Binding RefreshBookingsCommand}"/>
+                            </Grid>
+                        </Border>
+
                         <Border Style="{StaticResource CardStyle}">
                             <StackPanel Margin="25">
-                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding Bookings}">
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" Margin="0,0,0,10">
+                                    <TextBlock Text="Danh sách đặt phòng" FontSize="16" FontWeight="Bold" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Bookings.Count, StringFormat='{}Đang hiển thị {0} đặt phòng'}" Foreground="#FF666666" Margin="20,0,0,0" VerticalAlignment="Center"/>
+                                </StackPanel>
+
+                                <DataGrid Height="440"
+                                          AutoGenerateColumns="False"
+                                          CanUserAddRows="False"
+                                          ItemsSource="{Binding Bookings}"
+                                          IsReadOnly="True"
+                                          GridLinesVisibility="None"
+                                          HeadersVisibility="Column"
+                                          RowBackground="Transparent"
+                                          AlternatingRowBackground="#FFF6F8FB"
+                                          BorderBrush="Transparent"
+                                          ColumnHeaderHeight="40">
+                                    <DataGrid.Resources>
+                                        <Style TargetType="DataGridColumnHeader">
+                                            <Setter Property="Background" Value="Transparent"/>
+                                            <Setter Property="Foreground" Value="#FF374151"/>
+                                            <Setter Property="FontWeight" Value="SemiBold"/>
+                                            <Setter Property="FontSize" Value="13"/>
+                                            <Setter Property="Padding" Value="12,0"/>
+                                        </Style>
+                                    </DataGrid.Resources>
+
+                                    <DataGrid.RowStyle>
+                                        <Style TargetType="DataGridRow">
+                                            <Setter Property="Background" Value="Transparent"/>
+                                            <Setter Property="BorderThickness" Value="0"/>
+                                            <Setter Property="SnapsToDevicePixels" Value="True"/>
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="DataGridRow">
+                                                        <Border x:Name="RowBorder" Background="{TemplateBinding Background}" CornerRadius="10" Padding="8" Margin="0,4">
+                                                            <DataGridCellsPresenter/>
+                                                        </Border>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                            <Style.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="RowBorder" Property="Background" Value="#FFF1F5F9"/>
+                                                </Trigger>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter TargetName="RowBorder" Property="Background" Value="#FFE3F2FD"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </DataGrid.RowStyle>
+
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Booking ID" Width="200" Binding="{Binding BookingID}"/>
-                                        <DataGridTextColumn Header="Guest Name" Width="150" Binding="{Binding GuestName}"/>
-                                        <DataGridTextColumn Header="Room" Width="100" Binding="{Binding RoomNumber}"/>
-                                        <DataGridTextColumn Header="Check-in" Width="150" Binding="{Binding CheckInDate}"/>
-                                        <DataGridTextColumn Header="Check-out" Width="150" Binding="{Binding CheckOutDate}"/>
-                                        <DataGridTextColumn Header="Status" Width="120" Binding="{Binding Status}"/>
-                                        <DataGridTemplateColumn Header="Actions" Width="200">
+                                        <DataGridTextColumn Header="Mã đặt phòng" Width="180" Binding="{Binding BookingID}"/>
+                                        <DataGridTemplateColumn Header="Khách" Width="220">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <StackPanel Orientation="Horizontal">
-                                                        <Button Width="60" Height="25" Margin="2" FontSize="10" Background="#FF4CAF50"
-                                                            Command="{Binding DataContext.ConfirmBookingCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                                            CommandParameter="{Binding}">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding GuestName}" FontWeight="SemiBold"/>
+                                                        <TextBlock Text="{Binding NumberOfGuests, StringFormat='{}{0} khách'}" FontSize="11" Foreground="#FF6B7280"/>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTextColumn Header="Phòng" Width="100" Binding="{Binding RoomNumber}"/>
+                                        <DataGridTemplateColumn Header="Thời gian lưu trú" Width="220">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding CheckInDate, StringFormat='{}{0:dd MMM yyyy}'}" FontWeight="SemiBold"/>
+                                                        <TextBlock Text="{Binding CheckOutDate, StringFormat='{}Đến {0:dd MMM yyyy}'}" FontSize="11" Foreground="#FF6B7280"/>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTemplateColumn Header="Trạng thái" Width="160">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <Border Padding="12,6" CornerRadius="12" HorizontalAlignment="Left">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Background" Value="#FFEFF6FF"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding Status}" Value="Pending">
+                                                                        <Setter Property="Background" Value="#FFFFF4E5"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding Status}" Value="Confirmed">
+                                                                        <Setter Property="Background" Value="#FFE8F5E9"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding Status}" Value="Cancelled">
+                                                                        <Setter Property="Background" Value="#FFFFEBEE"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding Status}" Value="CancelledRequested">
+                                                                        <Setter Property="Background" Value="#FFFFF4E5"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
+                                                        <TextBlock Text="{Binding Status}" FontWeight="SemiBold" HorizontalAlignment="Center">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Foreground" Value="#FF1E3A8A"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Pending">
+                                                                            <Setter Property="Foreground" Value="#FFB26A00"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Confirmed">
+                                                                            <Setter Property="Foreground" Value="#FF2E7D32"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="Cancelled">
+                                                                            <Setter Property="Foreground" Value="#FFC62828"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding Status}" Value="CancelledRequested">
+                                                                            <Setter Property="Foreground" Value="#FFB26A00"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTemplateColumn Header="Thao tác" Width="200">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                                                        <Button Width="90"
+                                                                Height="32"
+                                                                Margin="0,0,8,0"
+                                                                Content="✔️ Xác nhận"
+                                                                Style="{StaticResource SecondaryButton}"
+                                                                Command="{Binding DataContext.ConfirmBookingCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                                CommandParameter="{Binding}">
                                                             <Button.Style>
                                                                 <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
                                                                     <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    <Setter Property="Content" Value="Confirm"/>
                                                                     <Style.Triggers>
                                                                         <DataTrigger Binding="{Binding Status}" Value="Pending">
                                                                             <Setter Property="Visibility" Value="Visible"/>
@@ -330,21 +561,21 @@
                                                                 </Style>
                                                             </Button.Style>
                                                         </Button>
-                                                        <Button Width="80" Height="25" Margin="2" FontSize="10" Background="#FFFF5722"
-                                                            Command="{Binding DataContext.CancelBookingCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                                            CommandParameter="{Binding}">
+                                                        <Button Width="120"
+                                                                Height="32"
+                                                                Content="🗑️ Xử lý hủy"
+                                                                Style="{StaticResource SecondaryButton}"
+                                                                Command="{Binding DataContext.CancelBookingCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                                CommandParameter="{Binding}">
                                                             <Button.Style>
                                                                 <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
                                                                     <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    <Setter Property="Content" Value="Cancel"/>
                                                                     <Style.Triggers>
                                                                         <DataTrigger Binding="{Binding Status}" Value="Pending">
                                                                             <Setter Property="Visibility" Value="Visible"/>
-                                                                            <Setter Property="Content" Value="Cancel"/>
                                                                         </DataTrigger>
                                                                         <DataTrigger Binding="{Binding Status}" Value="CancelledRequested">
                                                                             <Setter Property="Visibility" Value="Visible"/>
-                                                                            <Setter Property="Content" Value="Approve Cancel"/>
                                                                         </DataTrigger>
                                                                     </Style.Triggers>
                                                                 </Style>


### PR DESCRIPTION
## Summary
- refresh the hotel admin booking management tab with modern summary cards, improved filters, and a restyled bookings grid
- extend the view model with booking insight counters, search filtering, and a refresh command to support the new UI

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dead5cd6a083339f95ca8f447c3faf